### PR TITLE
Dedupe threshold setting & scrollbar for settings window

### DIFF
--- a/sammie/settings_dialog.py
+++ b/sammie/settings_dialog.py
@@ -259,6 +259,7 @@ class SettingsDialog(QDialog):
         self.deduplication_threshold_spin.setRange(0,1)
         self.deduplication_threshold_spin.setValue(0.8)
         self.deduplication_threshold_spin.setSingleStep(0.01)
+        self.deduplication_threshold_spin.setToolTip("Value from 0 to 1 used as a threshold for how similar masks have to be before they're considered the same and deduped.\nHigher values are more strict.")
         deduplication_layout.addRow("Threshold:", self.deduplication_threshold_spin)
         
         layout.addWidget(deduplication_group)


### PR DESCRIPTION
I ran into a few instances where the default dedupe similarity threshold (0.8) wasn't low enough to catch all the duplicate mask frames I wanted it to deduplicate. So the value has been made accessible in the settings window so that users can adjust it easily.

Also with the amount of settings growing, a vertical scrollbar has been added to prevent the window of growing vertically indefinitely.

https://github.com/user-attachments/assets/c57e171a-2eb2-4648-b9af-224b020b12a3

