### PR TITLE
Redo deduplication functionality by backing up original masks

### DIFF
--- a/sammie/duplicate_frame_handler.py
+++ b/sammie/duplicate_frame_handler.py
@@ -69,7 +69,7 @@ def replace_files_similar_mattes(mask_dir, similar_frames):
             shutil.copy(file_path, replace_mask_dir)
 
 def backup_mattes(mask_dir, backup_dir):
-    print("Creating original masks backup")
+    #print("Creating original masks backup")
     if os.path.exists(backup_dir):
         shutil.rmtree(backup_dir)
     shutil.copytree(mask_dir, backup_dir)

--- a/sammie/sammie.py
+++ b/sammie/sammie.py
@@ -33,6 +33,7 @@ from minimax_remover.transformer_minimax_remover import Transformer3DModel
 temp_dir = "temp"
 frames_dir = os.path.join(temp_dir, "frames")
 mask_dir = os.path.join(temp_dir, "masks")
+backup_dir = os.path.join(temp_dir, "masks_backup")
 matting_dir = os.path.join(temp_dir, "matting")
 removal_dir = os.path.join(temp_dir, "removal")
 smoothing_model = None #global variable needed to avoid complexity of passing the model around
@@ -2088,6 +2089,10 @@ def deduplicate_masks(parent_window):
     settings_mgr = get_settings_manager()
     threshold = settings_mgr.app_settings.dedupe_threshold
     return replace_similar_matte_frames(parent_window, threshold)
+
+def remove_backup_mattes():
+    if os.path.exists(backup_dir):
+        shutil.rmtree(backup_dir)
     
 
 def load_video(video_file, parent_window):


### PR DESCRIPTION
### Goal
Now that it's possible to adjust the threshold of the deduplication functionality, it would be nice to retry deduplication of similar frames with different thresholds, without having to track the objects again. (This was needed to restore the original masks as those get overwritten with dedupe)

### Implementation
The following functions have been added.

**_backup_mattes:_** after having tracked the objects, once the user clicks on the dedupe button for the first time, the original masks get backed up in the temp folder.

**_restore_backup_mattes:_** if the user decides the deduplicate the frames again, instead of using the current deduplicated frames, it first restores the original masks and dedupes on those.

**_remove_backup_mattes:_** function to call if the backup folder needs to be removed outside of the dedupe functionality.

### Result
The user is able to dedupe multiple times without having to run the track objects functionality.

https://github.com/user-attachments/assets/f57442b9-7db0-4b93-b516-9d78e40f0ca4



