### PR TITLE
Linux file extension fix by using Qt instead of native OS dialog window

### DIFF
--- a/sammie_main.py
+++ b/sammie_main.py
@@ -2458,8 +2458,6 @@ class MainWindow(QMainWindow):
         save_dialog.setAcceptMode(QFileDialog.AcceptSave)
         save_dialog.setNameFilter("JSON Files (*.json)")
         save_dialog.setDefaultSuffix("json")
-        # Use Qt's dialog window instead of the OS native one, for more consistency.
-        save_dialog.setOption(QFileDialog.DontUseNativeDialog, True)
 
         # Wait for the user to execute the save before continuing.
         if save_dialog.exec_() == QDialog.Accepted:
@@ -2493,8 +2491,6 @@ class MainWindow(QMainWindow):
         save_dialog.setAcceptMode(QFileDialog.AcceptSave)
         save_dialog.setNameFilter("Sammie Files (*.sammie)")
         save_dialog.setDefaultSuffix("sammie")
-        # Use Qt's dialog window instead of the OS native one, for more consistency.
-        save_dialog.setOption(QFileDialog.DontUseNativeDialog, True)
 
         # Wait for the user to execute the save before continuing.
         if save_dialog.exec_() == QDialog.Accepted:


### PR DESCRIPTION
**Goal:**
Fix issue #12 

**Changes:**
Due to differences between different operating systems, the way file names and extensions are handled can differ.
To solve this problem, the code is adjusted to force the function to use Qt's own dialog window, this way the saving functionality should be more universal across different operating systems and in this example the file extension can be processed correctly.

**Result:**
The file saving window now uses Qt's dialog system.
<img width="818" height="556" alt="image" src="https://github.com/user-attachments/assets/d5d0501b-92ce-4cea-b5bf-c2f4062664d1" />

If possible perhaps it's an idea to improve navigation by defaulting to a specific folder, as now it defaults to the user's root/home directory.
