### PR TITLE
refactor the export dialog

### DIFF
--- a/sammie/export_dialog.py
+++ b/sammie/export_dialog.py
@@ -1,353 +1,64 @@
 # sammie/export_dialog.py
+"""
+Export dialog for video and sequence exports.
+Refactored for clarity and extensibility.
+"""
 import os
-import av
 import datetime
-import numpy as np
-import OpenEXR
-import Imath
-from fractions import Fraction
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox,
     QPushButton, QLabel, QLineEdit, QComboBox, QSpinBox, QCheckBox,
-    QFileDialog, QProgressDialog, QApplication, QMessageBox
+    QFileDialog, QProgressDialog, QMessageBox
 )
-from PySide6.QtCore import Qt, QThread, Signal
+from PySide6.QtCore import Qt
 from sammie import sammie
 from sammie.gui_widgets import show_message_dialog
+from .export_formats import FormatRegistry, ExportSettings
+from .export_workers import VideoExportWorker, SequenceExportWorker
 
 
-class ExportWorker(QThread):
-    """Worker thread for video export to prevent GUI freezing"""
+class ExportPathManager:
+    """Manages path generation and template resolution"""
     
-    progress_updated = Signal(int)  # Progress percentage
-    status_updated = Signal(str)    # Status message
-    finished = Signal(bool, str)    # Success flag and message
+    def __init__(self, settings_mgr):
+        self.settings_mgr = settings_mgr
     
-    def __init__(self, export_params, points, total_frames, export_multiple=False, object_ids=None, parent_window=None):
-        super().__init__()
-        self.export_params = export_params
-        self.points = points
-        self.total_frames = total_frames
-        self.should_cancel = False
-        self.export_multiple = export_multiple
-        self.object_ids = object_ids or []
-        self.parent_window = parent_window
-        self.object_names = export_params.get('object_names', {})
+    def resolve_template(self, template: str, format_id: str, output_type: str, 
+                        object_id: int = None) -> str:
+        """Resolve template tags to actual values"""
+        # Get input file info
+        input_file = self.settings_mgr.get_session_setting("video_file_path", "")
+        base_name = os.path.splitext(os.path.basename(input_file))[0] if input_file else "video"
         
-        # Handle in/out points
-        self.use_inout = export_params.get('use_inout', False)
-        self.in_point = export_params.get('in_point', 0)
-        self.out_point = export_params.get('out_point', total_frames - 1)
+        # Get in/out points
+        total_frames = sammie.VideoInfo.total_frames
+        in_point = self.settings_mgr.get_session_setting("in_point", 0)
+        out_point = self.settings_mgr.get_session_setting("out_point", total_frames - 1)
         
-        # Calculate actual frame range to export
-        if self.use_inout and self.in_point is not None and self.out_point is not None:
-            self.start_frame = max(0, self.in_point)
-            self.end_frame = min(total_frames - 1, self.out_point)
-            self.export_frame_count = self.end_frame - self.start_frame + 1
-        else:
-            self.start_frame = 0
-            self.end_frame = total_frames - 1
-            self.export_frame_count = total_frames
-        
-    def cancel(self):
-        self.should_cancel = True
-        
-    def run(self):
-        try:
-            if self.export_params['codec'] == 'exr':
-                self._export_exr_sequence()
-            elif self.export_multiple:
-                self._export_multiple_videos()
-            else:
-                self._export_video()
-        except Exception as e:
-            import traceback
-            tb = traceback.format_exc()
-            self.finished.emit(False, f"Export failed: {e}\n\n{tb}")
-    
-    def _export_exr_sequence(self):
-        """Export OpenEXR frame sequence with multiple object layers"""
-        output_dir = self.export_params['output_path']
-        base_filename = self.export_params['base_filename']
-        include_original = self.export_params.get('include_original', False)
-        
-        # Get all unique object IDs from points
-        all_object_ids = sorted(set(point['object_id'] for point in self.points))
-        
-        if not all_object_ids:
-            self.finished.emit(False, "No objects found to export")
-            return
-        
-        # Get object names from session settings
-        object_names = {}
-        if self.parent_window and hasattr(self.parent_window, 'settings_mgr'):
-            object_names = self.parent_window.settings_mgr.get_session_setting("object_names", {})
-        
-        exported_files = []
-        
-        for i, frame_num in enumerate(range(self.start_frame, self.end_frame + 1)):
-            if self.should_cancel:
-                self.status_updated.emit("Export cancelled")
-                # Clean up any partially created files
-                for file_path in exported_files:
-                    if os.path.exists(file_path):
-                        os.remove(file_path)
-                self.finished.emit(False, "Export was cancelled")
-                return
-            
-            self.status_updated.emit(f"Exporting frame {frame_num + 1}/{self.end_frame + 1}...")
-            
-            # Generate filename for this frame using actual frame number
-            frame_filename = f"{base_filename}.{frame_num:04d}.exr"
-            frame_path = os.path.join(output_dir, frame_filename)
-            
-            try:
-                # Collect all object masks for this frame
-                exr_data = {}
-                
-                # Get matte view options
-                view_options = {
-                    'view_mode': self.export_params.get('output_type', 'Segmentation-Matte'),
-                    'antialias': self.export_params.get('antialias', False)
-                }
-                
-                # Export each object as a separate layer
-                for obj_id in all_object_ids:
-                    mask_array = sammie.update_image(
-                        frame_num, view_options, self.points, 
-                        return_numpy=True, object_id_filter=obj_id
-                    )
-                    
-                    if mask_array is not None:
-                        # Convert to grayscale if needed (matte should already be grayscale)
-                        if len(mask_array.shape) == 3 and mask_array.shape[2] > 1:
-                            mask_array = mask_array[:, :, 0]  # Take first channel
-                        
-                        # Normalize to 0-1 range for EXR
-                        if mask_array.dtype == np.uint8:
-                            mask_array = mask_array.astype(np.float32) / 255.0
-                        elif mask_array.dtype != np.float32:
-                            mask_array = mask_array.astype(np.float32)
-                        
-                        # Generate layer name with object name if available
-                        object_name = object_names.get(str(obj_id), "")
-                        if object_name:
-                            # Sanitize object name for EXR layer naming
-                            sanitized_name = self._sanitize_layer_name(object_name)
-                            layer_name = f'{obj_id}_{sanitized_name}'
-                        else:
-                            layer_name = f'{obj_id}'
-                        
-                        exr_data[layer_name] = mask_array
-                
-                # Include original frame if requested
-                if include_original:
-                    # Get original frame without any segmentation overlay
-                    original_view_options = {
-                        'view_mode': 'None',  # return original frame
-                    }
-                    
-                    original_array = sammie.update_image(
-                        frame_num, original_view_options, self.points, 
-                        return_numpy=True, object_id_filter=None
-                    )
-                    
-                    if original_array is not None:
-                        # Convert to float32 and normalize if needed
-                        if original_array.dtype == np.uint8:
-                            original_array = original_array.astype(np.float32) / 255.0
-                        elif original_array.dtype != np.float32:
-                            original_array = original_array.astype(np.float32)
-                        
-                        # Split RGB channels for EXR
-                        if len(original_array.shape) == 3 and original_array.shape[2] >= 3:
-                            exr_data['original.R'] = original_array[:, :, 0]
-                            exr_data['original.G'] = original_array[:, :, 1]
-                            exr_data['original.B'] = original_array[:, :, 2]
-                        else:
-                            exr_data['original'] = original_array
-                
-                # Write EXR file
-                if exr_data:
-                    self._write_exr_file(frame_path, exr_data)
-                    exported_files.append(frame_path)
-                
-                # Update progress based on frames exported
-                progress = int((i + 1) / self.export_frame_count * 100)
-                self.progress_updated.emit(progress)
-                
-            except Exception as e:
-                print (f"Error exporting frame {frame_num + 1}: {e}")
-                # Clean up on error
-                for file_path in exported_files:
-                    if os.path.exists(file_path):
-                        os.remove(file_path)
-                raise e
-        
-        if not self.should_cancel:
-            self.status_updated.emit("EXR sequence export completed")
-            frame_range_msg = f" (frames {self.start_frame}-{self.end_frame})" if self.use_inout else ""
-            self.finished.emit(True, f"Successfully exported {len(exported_files)} EXR frames{frame_range_msg} to {output_dir}")
-
-    def _sanitize_layer_name(self, name):
-        """Sanitize object name for use in EXR layer naming"""
-        import re
-        # Replace spaces and special characters with underscores
-        sanitized = re.sub(r'[^\w]', '_', name)
-        # Remove multiple consecutive underscores
-        sanitized = re.sub(r'_+', '_', sanitized)
-        # Remove leading/trailing underscores
-        sanitized = sanitized.strip('_')
-        # Limit length to reasonable size
-        if len(sanitized) > 20:
-            sanitized = sanitized[:20]
-        return sanitized if sanitized else "unnamed"
-
-    def _sanitize_filename_component(self, name):
-        """Sanitize name for use in filenames"""
-        import re
-        if not name:
-            return ""
-        # Replace spaces and special characters with underscores
-        sanitized = re.sub(r'[^\w]', '_', name)
-        # Remove multiple consecutive underscores
-        sanitized = re.sub(r'_+', '_', sanitized)
-        # Remove leading/trailing underscores
-        sanitized = sanitized.strip('_')
-        # Limit length to reasonable size
-        if len(sanitized) > 20:
-            sanitized = sanitized[:20]
-        return sanitized if sanitized else "unnamed"
-
-    def _write_exr_file(self, filepath, data_dict):
-        """Write EXR file with multiple layers using Python OpenEXR"""
-        try:
-            first_layer = next(iter(data_dict.values()))
-            height, width = first_layer.shape
-
-            header = OpenEXR.Header(width, height)
-            FLOAT = Imath.PixelType(Imath.PixelType.FLOAT)
-
-            # Declare channels
-            for name in data_dict.keys():
-                header['channels'][name] = Imath.Channel(FLOAT)
-
-            # Enable PIZ compression
-            header['compression'] = Imath.Compression(Imath.Compression.PIZ_COMPRESSION)
-
-            out = OpenEXR.OutputFile(filepath, header)
-
-            # Prepare channel data
-            channels = {}
-            for name, arr in data_dict.items():
-                if arr.dtype != np.float32:
-                    arr = arr.astype(np.float32)
-                arr = np.ascontiguousarray(arr)
-                channels[name] = arr.tobytes()
-
-            out.writePixels(channels)
-            out.close()
-
-        except Exception as e:
-            raise RuntimeError(f"Failed to write EXR file: {e}")
-    
-    def _export_multiple_videos(self):
-        """Export individual videos for each object ID"""
-        total_exports = len(self.object_ids)
-        total_progress_steps = total_exports * self.export_frame_count
-        current_step = 0
-        
-        exported_files = []
-        
-        for i, object_id in enumerate(self.object_ids):
-            if self.should_cancel:
-                self.status_updated.emit("Export cancelled")
-                # Clean up any partially created files
-                for file_path in exported_files:
-                    if os.path.exists(file_path):
-                        os.remove(file_path)
-                self.finished.emit(False, "Export was cancelled")
-                return
-            
-            # Update export params for current object
-            current_params = self.export_params.copy()
-            current_params['object_id'] = object_id
-            
-            # Generate output path for this object
-            output_path = self._generate_object_output_path(object_id)
-            current_params['output_path'] = output_path
-            
-            self.status_updated.emit(f"Exporting object {object_id} ({i+1}/{total_exports})...")
-            
-            try:
-                self._export_single_video(current_params, current_step, total_progress_steps)
-                exported_files.append(output_path)
-                current_step += self.export_frame_count
-            except Exception as e:
-                # Clean up any partially created files
-                for file_path in exported_files:
-                    if os.path.exists(file_path):
-                        os.remove(file_path)
-                raise e
-        
-        if not self.should_cancel:
-            self.status_updated.emit("All exports completed successfully")
-            files_text = "\n".join([os.path.basename(f) for f in exported_files])
-            frame_range_msg = f" (frames {self.start_frame}-{self.end_frame})" if self.use_inout else ""
-            self.finished.emit(True, f"Successfully exported {len(exported_files)} videos{frame_range_msg}:\n{files_text}")
-    
-    def _generate_object_output_path(self, object_id):
-        """Generate output path for a specific object ID using the filename template"""
-        # Get the template and directory from export params
-        template = self.export_params['filename_template']
-        directory = self.export_params['output_path']  # This is now just the folder path
-        
-        # Resolve the template with the specific object ID
-        resolved_name = self._resolve_template_for_object(template, object_id)
-        
-        # Get extension from codec
-        codec = self.export_params['codec']
-        if codec == 'prores':
-            ext = '.mov'
-        elif codec == 'ffv1':
-            ext = '.mkv'
-        elif codec == 'vp9':
-            ext = '.webm'
-        else:
-            ext = '.mp4'
-        
-        return os.path.join(directory, resolved_name + ext)
-    
-    def _resolve_template_for_object(self, template, object_id):
-        """Resolve filename template for a specific object ID"""
-        base_params = self.export_params
+        # Get timestamp
         now = datetime.datetime.now()
         
-        # Get object names from parent window if available
-        object_name = ""
-        if self.parent_window and hasattr(self.parent_window, 'settings_mgr'):
-            object_names = self.parent_window.settings_mgr.get_session_setting("object_names", {})
-            object_name = object_names.get(str(object_id), "")
-        elif hasattr(self, 'object_names'):
-            object_name = self.object_names.get(str(object_id), "")
-
-        # Provide default name if empty
-        if not object_name.strip():
-            if object_id == -1:
-                object_name = "all"
-            else:
-                object_name = f"object_{object_id}"
-
-        sanitized_object_name = self._sanitize_filename_component(object_name)
-
+        # Handle object name/ID
+        if object_id is not None and object_id != -1:
+            object_names = self.settings_mgr.get_session_setting("object_names", {})
+            raw_object_name = object_names.get(str(object_id), "")
+            if not raw_object_name.strip():
+                raw_object_name = f"object_{object_id}"
+            sanitized_object_name = self._sanitize_name(raw_object_name)
+            obj_id_str = str(object_id)
+        else:
+            sanitized_object_name = "all"
+            obj_id_str = "all"
+        
+        # Tag replacement dictionary
         tag_values = {
-            "input_name": base_params.get('input_name', 'video'),
-            "output_type": base_params.get('output_type', ''),
-            "codec": base_params.get('codec', ''),
-            "object_id": str(object_id),
+            "input_name": base_name,
+            "output_type": output_type,
+            "codec": format_id,
+            "object_id": obj_id_str,
             "object_name": sanitized_object_name,
-            "in_point": str(base_params.get('in_point', '')),
-            "out_point": str(base_params.get('out_point', '')),
+            "in_point": str(in_point),
+            "out_point": str(out_point),
             "date": now.strftime("%Y%m%d"),
             "time": now.strftime("%H%M%S"),
             "datetime": now.strftime("%Y%m%d_%H%M%S"),
@@ -355,310 +66,138 @@ class ExportWorker(QThread):
         
         result = template
         for tag, value in tag_values.items():
-            result = result.replace(f"{{{tag}}}", value)
+            result = result.replace(f"{{{tag}}}", str(value))
+        
         return result
     
-    def _export_video(self):
-        """Main export logic for single video"""
-        self._export_single_video(self.export_params, 0, self.export_frame_count)
+    def generate_output_path(self, output_dir: str, template: str, format_id: str,
+                           output_type: str, object_id: int = None) -> str:
+        """Generate full output path with extension"""
+        resolved_name = self.resolve_template(template, format_id, output_type, object_id)
+        format_obj = FormatRegistry.get_format(format_id)
+        ext = format_obj.file_extension
         
-        if not self.should_cancel:
-            self.status_updated.emit("Export completed successfully")
-            frame_range_msg = f" (frames {self.start_frame}-{self.end_frame})" if self.use_inout else ""
-            self.finished.emit(True, f"Video exported successfully{frame_range_msg} to {self.export_params['output_path']}")
+        # For sequences, don't add extension here (will be added per frame)
+        if format_obj.is_sequence:
+            return os.path.join(output_dir, resolved_name)
+        else:
+            return os.path.join(output_dir, resolved_name + ext)
     
-    def _export_single_video(self, params, progress_offset, total_progress_steps):
-        """Export a single video with given parameters"""
-        output_path = params['output_path']
-        codec = params['codec']
-        output_type = params['output_type']
-        antialias = params['antialias']
-        quantizer = params.get('quantizer', 14)
-        object_id_filter = None if params['object_id'] == -1 else params['object_id']
-        
-        # Create output container and stream
-        container = av.open(output_path, mode='w')
-        
-        # Convert float framerates to fraction
-        fps = sammie.VideoInfo.fps
-        if abs(fps - 29.97) < 0.01:
-            fps_rational = Fraction(30000, 1001)
-        elif abs(fps - 23.976) < 0.01:
-            fps_rational = Fraction(24000, 1001)
-        elif abs(fps - 59.94) < 0.01:
-            fps_rational = Fraction(60000, 1001)
-        else:
-            fps_rational = Fraction(fps).limit_denominator()
-        
-        # Configure codec options
-        codec_options = {}
-        if codec == 'prores':
-            stream = container.add_stream('prores_ks', rate=fps_rational)
-            stream.pix_fmt = 'yuv422p10le'
-            codec_options = {'profile': '3'}  # ProRes HQ
-        elif codec == 'ffv1':
-            stream = container.add_stream('ffv1', rate=fps_rational)
-            codec_options = {'level': '3'}
-            stream.pix_fmt = 'bgr0'
-        elif codec == 'vp9':
-            stream = container.add_stream('libvpx-vp9', rate=fps_rational)
-            codec_options = {
-                'crf': str(quantizer),
-                'b': '0',  # Use constant quality mode
-                'row-mt': '1'  # Enable row-based multithreading
-            }
-            stream.pix_fmt = 'yuv420p'
-        elif codec == 'x264':
-            stream = container.add_stream('libx264', rate=fps_rational)
-            codec_options = {'crf': str(quantizer), 'preset': 'medium'}
-            stream.pix_fmt = 'yuv420p'
-        elif codec == 'x265':
-            stream = container.add_stream('libx265', rate=fps_rational)
-            codec_options = {'crf': str(quantizer), 'preset': 'medium'}
-            stream.pix_fmt = 'yuv420p'
-        
-        # Set stream properties
-        stream.width = sammie.VideoInfo.width
-        stream.height = sammie.VideoInfo.height
-        
-        # Set custom options for alpha channel
-        has_alpha = ('Alpha' in output_type)
-        if has_alpha:
-            if codec == 'prores':
-                stream.pix_fmt='yuva444p10le'
-                codec_options = {'profile': '4'}  # 4444
-            elif codec == 'ffv1':
-                stream.pix_fmt = 'bgra'
-            elif codec == 'vp9':
-                stream.pix_fmt = 'yuva420p'
-        
-        # Set codec options
-        for key, value in codec_options.items():
-            stream.options[key] = value
-        
-        try:
-            # Process each frame in the range
-            pts_counter = 0  # Start PTS from 0 for the exported video
-            for i, frame_num in enumerate(range(self.start_frame, self.end_frame + 1)):
-                if self.should_cancel:
-                    self.status_updated.emit("Export cancelled")
-                    container.close()
-                    if os.path.exists(output_path):
-                        os.remove(output_path)
-                    self.finished.emit(False, "Export was cancelled")
-                    return
-                
-                # Get the appropriate view options for export
-                view_options = self._get_export_view_options(output_type, antialias)
-                
-                # Get frame data using existing update_image function with numpy return
-                frame_array = sammie.update_image(frame_num, view_options, self.points, return_numpy=True, object_id_filter=object_id_filter)
-                if frame_array is None:
-                    continue
-                
-                # Ensure frame_array is in the correct format for AV
-                if has_alpha and frame_array.shape[2] != 4:
-                    # Add alpha channel if missing
-                    alpha_channel = np.full((frame_array.shape[0], frame_array.shape[1], 1), 255, dtype=np.uint8)
-                    frame_array = np.concatenate([frame_array, alpha_channel], axis=2)
-                elif not has_alpha and frame_array.shape[2] == 4:
-                    # Remove alpha channel if not needed
-                    frame_array = frame_array[:, :, :3]
-                
-                # Create AV frame - handle color channel ordering for AV
-                if has_alpha:
-                    # RGBA format for alpha
-                    av_frame = av.VideoFrame.from_ndarray(frame_array, format='rgba')
-                else:
-                    # RGB format for standard video
-                    av_frame = av.VideoFrame.from_ndarray(frame_array, format='rgb24')
-                    
-                # Use renumbered PTS starting from 0
-                av_frame.pts = pts_counter
-                pts_counter += 1
-                
-                # Encode and write frame
-                for packet in stream.encode(av_frame):
-                    container.mux(packet)
-                
-                # Update progress based on frames exported
-                current_progress_step = progress_offset + i + 1
-                progress = int(current_progress_step / total_progress_steps * 100)
-                self.progress_updated.emit(progress)
-            
-            # Flush remaining frames
-            for packet in stream.encode():
-                container.mux(packet)
-                
-        finally:
-            container.close()
+    def check_existing_files(self, paths: list) -> list:
+        """Check which files already exist"""
+        return [p for p in paths if os.path.exists(p)]
     
-    def _get_export_view_options(self, output_type, antialias):
-        """Get view options for export based on output type"""
-        # Get bgcolor from session settings
-        settings_mgr = self.parent_window.settings_mgr if self.parent_window else None
-        if settings_mgr:
-            bgcolor = settings_mgr.get_session_setting("bgcolor", (0, 255, 0))
-        else:
-            bgcolor = (0, 255, 0)
-
-        if output_type == 'Segmentation-Matte':
-            return {
-                'view_mode': 'Segmentation-Matte',
-                'antialias': antialias
-            }
-        elif output_type == 'Segmentation-Alpha':
-            return {
-                'view_mode': 'Segmentation-Alpha', 
-                'antialias': antialias
-            }
-        elif output_type == 'Segmentation-BGcolor':
-            return {
-                'view_mode': 'Segmentation-BGcolor',
-                'antialias': antialias,
-                'bgcolor': bgcolor
-            }
-        elif output_type == 'Matting-Matte':
-            return {
-                'view_mode': 'Matting-Matte'
-            }
-        elif output_type == 'Matting-Alpha':
-            return {
-                'view_mode': 'Matting-Alpha'
-            }
-        elif output_type == 'Matting-BGcolor':
-            return {
-                'view_mode': 'Matting-BGcolor',
-                'bgcolor': bgcolor
-            }
-        elif output_type == 'ObjectRemoval':
-            return {
-                'view_mode': 'ObjectRemoval',
-                'show_removal_mask': False
-            }
-        else:
-            return {
-                'view_mode': 'Segmentation-Edit',
-                'show_masks': True,
-                'show_outlines': False
-            }
+    @staticmethod
+    def _sanitize_name(name: str) -> str:
+        """Sanitize name for use in filenames"""
+        import re
+        if not name:
+            return "unnamed"
+        sanitized = re.sub(r'[^\w]', '_', name)
+        sanitized = re.sub(r'_+', '_', sanitized)
+        sanitized = sanitized.strip('_')
+        return sanitized[:20] if len(sanitized) > 20 else sanitized or "unnamed"
 
 
 class ExportDialog(QDialog):
-    """Dialog for configuring video export settings"""
+    """Main export dialog"""
     
     def __init__(self, parent=None):
         super().__init__(parent)
         self.parent_window = parent
         self.export_worker = None
         self.progress_dialog = None
+        self.path_manager = ExportPathManager(parent.settings_mgr) if parent else None
+        self.current_format = None
+        
         self.setWindowTitle("Export Video")
         self.setModal(True)
         self.resize(500, 520)
-        self._init_ui()
-
         
+        self._init_ui()
+        self._load_saved_settings()
+    
     def _init_ui(self):
-        """Initialize the dialog UI"""
+        """Initialize dialog UI"""
         layout = QVBoxLayout(self)
+        
         self._create_output_section(layout)
         self._create_settings_section(layout)
         self._create_buttons(layout)
-        self._update_filename_preview()
-        self._load_saved_settings()
+        
+        # Set initial format
+        if self.format_combo.count() > 0:
+            self._on_format_changed(0)
     
     def _create_output_section(self, layout):
         """Create output file selection section"""
-        output_group = QGroupBox("Output File")
+        output_group = QGroupBox("Output")
         output_layout = QFormLayout(output_group)
         
-        # Output folder selection
+        # Output folder
         folder_layout = QHBoxLayout()
         self.folder_edit = QLineEdit()
         self.folder_edit.setPlaceholderText("Select output folder...")
+        self.folder_edit.textChanged.connect(self._update_filename_preview)
         folder_layout.addWidget(self.folder_edit)
-
+        
         self.browse_btn = QPushButton("Browse...")
         self.browse_btn.clicked.connect(self._browse_output_folder)
         folder_layout.addWidget(self.browse_btn)
-
+        
         output_layout.addRow("Output Folder:", folder_layout)
-
-        # Checkbox to use input folder
+        
+        # Use input folder checkbox
         self.use_input_folder_checkbox = QCheckBox("Use same folder as input file")
         self.use_input_folder_checkbox.stateChanged.connect(self._on_use_input_folder_changed)
         output_layout.addRow("", self.use_input_folder_checkbox)
         
-        # Filename template with tag dropdown
+        # Filename template
         template_layout = QHBoxLayout()
         self.filename_template_edit = QLineEdit()
         self.filename_template_edit.setPlaceholderText("{input_name}-{output_type}")
         self.filename_template_edit.textChanged.connect(self._update_filename_preview)
         template_layout.addWidget(self.filename_template_edit)
-
+        
         self.tag_dropdown = QComboBox()
-        self.tag_dropdown.addItem("Insert tag...")  # placeholder
+        self.tag_dropdown.addItem("Insert tag...")
         self.tag_dropdown.addItems([
-        "{input_name}", "{output_type}", "{object_id}", 
-        "{object_name}", "{codec}", "{in_point}", "{out_point}", 
-        "{date}", "{time}", "{datetime}"
+            "{input_name}", "{output_type}", "{object_id}", "{object_name}",
+            "{codec}", "{in_point}", "{out_point}", "{date}", "{time}", "{datetime}"
         ])
-        self.tag_dropdown.currentIndexChanged.connect(self._insert_tag_into_template)
+        self.tag_dropdown.currentIndexChanged.connect(self._insert_tag)
         template_layout.addWidget(self.tag_dropdown)
-
+        
         output_layout.addRow("Filename:", template_layout)
         
-        # Preview label
+        # Preview
         self.filename_preview_label = QLabel()
         self.filename_preview_label.setStyleSheet("color: gray; font-style: italic;")
         self.filename_preview_label.setWordWrap(True)
         output_layout.addRow("Preview:", self.filename_preview_label)
         
-        # Codec selection
-        self.codec_combo = QComboBox()
-        self.codec_combo.addItems(['prores', 'ffv1', 'x264', 'x265', 'vp9', 'exr'])
-        self.codec_combo.currentTextChanged.connect(self._on_codec_changed)
-        output_layout.addRow("Codec:", self.codec_combo)
-
-        # Alpha unsupported message (hidden by default)
-        self.alpha_warning_label = QLabel("Alpha channel is not supported with x264 or x265.")
-        self.alpha_warning_label.setStyleSheet("color: orange;")
-        self.alpha_warning_label.setWordWrap(True)
-        self.alpha_warning_label.setVisible(False)
-        output_layout.addRow("", self.alpha_warning_label)
-        
         layout.addWidget(output_group)
     
-    def _insert_tag_into_template(self, index):
-        if index <= 0:
-            return  # Ignore placeholder
-        tag = self.tag_dropdown.itemText(index)
-        cursor_pos = self.filename_template_edit.cursorPosition()
-        text = self.filename_template_edit.text()
-        new_text = text[:cursor_pos] + tag + text[cursor_pos:]
-        self.filename_template_edit.setText(new_text)
-        # Reset dropdown back to placeholder
-        self.tag_dropdown.setCurrentIndex(0)
-        # Move cursor after inserted tag
-        self.filename_template_edit.setCursorPosition(cursor_pos + len(tag))
-
     def _create_settings_section(self, layout):
         """Create export settings section"""
-        settings_group = QGroupBox("Export Settings")
+        settings_group = QGroupBox("Format & Settings")
         settings_layout = QFormLayout(settings_group)
         
-        # Output type selection
+        # Format selection
+        self.format_combo = QComboBox()
+        for fmt in FormatRegistry.get_all_formats():
+            self.format_combo.addItem(fmt.display_name, fmt.format_id)
+        self.format_combo.currentIndexChanged.connect(self._on_format_changed)
+        settings_layout.addRow("Export Format:", self.format_combo)
+        
+        # Output type
         self.output_type_combo = QComboBox()
-        self.output_type_combo.addItems([
-            'Segmentation-Matte', 'Segmentation-Alpha', 'Segmentation-BGcolor',
-            'Matting-Matte', 'Matting-Alpha', 'Matting-BGcolor', 'ObjectRemoval'
-        ])
         self.output_type_combo.currentTextChanged.connect(self._on_output_type_changed)
         settings_layout.addRow("Output Type:", self.output_type_combo)
         
-        # Object ID selection
+        # Object selection
         self.object_id_combo = QComboBox()
-        self.object_id_combo.addItem("All Objects", -1)  # -1 means all objects
+        self.object_id_combo.addItem("All Objects", -1)
         if self.parent_window and hasattr(self.parent_window, 'point_manager'):
             points = self.parent_window.point_manager.get_all_points()
             if points:
@@ -667,18 +206,13 @@ class ExportDialog(QDialog):
                     self.object_id_combo.addItem(f"Object {obj_id}", obj_id)
         self.object_id_combo.currentIndexChanged.connect(self._update_filename_preview)
         settings_layout.addRow("Export Object:", self.object_id_combo)
-
+        
         # Export multiple objects checkbox
-        self.export_multiple_checkbox = QCheckBox("Export videos for each object")
+        self.export_multiple_checkbox = QCheckBox("Export separate file for each object")
         self.export_multiple_checkbox.stateChanged.connect(self._on_export_multiple_changed)
         settings_layout.addRow("", self.export_multiple_checkbox)
-
-        # Include original frame checkbox (for EXR only)
-        self.include_original_checkbox = QCheckBox("Include original frame as layer")
-        self.include_original_checkbox.setVisible(False)
-        settings_layout.addRow("", self.include_original_checkbox)
         
-        # Quantizer setting (for x264/x265/vp9)
+        # Quality setting
         self.quantizer_spin = QSpinBox()
         self.quantizer_spin.setRange(0, 51)
         self.quantizer_spin.setValue(14)
@@ -686,48 +220,23 @@ class ExportDialog(QDialog):
         settings_layout.addRow("Quality (CRF):", self.quantizer_spin)
         self.quantizer_label = settings_layout.labelForField(self.quantizer_spin)
         
-        # Antialiasing checkbox
+        # Antialiasing
         self.antialias_checkbox = QCheckBox("Antialiasing")
         self.antialias_checkbox.setChecked(False)
         settings_layout.addRow("", self.antialias_checkbox)
         
-        # In/Out points checkbox
+        # Include original (EXR only)
+        self.include_original_checkbox = QCheckBox("Include original frame as layer")
+        self.include_original_checkbox.setVisible(False)
+        settings_layout.addRow("", self.include_original_checkbox)
+        
+        # In/Out points
         self.use_inout_checkbox = QCheckBox("Export only between in/out markers")
         self.use_inout_checkbox.setChecked(True)
         settings_layout.addRow("", self.use_inout_checkbox)
-
+        
         layout.addWidget(settings_group)
-        
-        # Initialize UI state based on default selection
-        self._on_codec_changed(self.codec_combo.currentText())
-        self._on_output_type_changed()
-
-    def _on_output_type_changed(self):
-        """Handle output type selection changes"""
-        output_type = self.output_type_combo.currentText()
-        
-        # Show/hide antialiasing based on whether it's a Segmentation mode
-        is_segmentation = output_type.startswith('Segmentation-')
-        self.antialias_checkbox.setVisible(is_segmentation)
-
-        # Show/hide object selection for ObjectRemoval mode
-        is_object_removal = output_type.startswith('ObjectRemoval')
-        self.object_id_combo.setEnabled(not is_object_removal)
-        self.export_multiple_checkbox.setVisible(not is_object_removal)
-        
-        # Update filename preview
-        self._update_filename_preview()
-
-    def _on_export_multiple_changed(self, state):
-        """Handle changes to the export multiple checkbox"""
-        export_multiple = self.export_multiple_checkbox.isChecked()
-        
-        # Disable/enable object selection
-        self.object_id_combo.setEnabled(not export_multiple)
-        
-        # Update filename preview
-        self._update_filename_preview()
-        
+    
     def _create_buttons(self, layout):
         """Create dialog buttons"""
         button_layout = QHBoxLayout()
@@ -743,307 +252,358 @@ class ExportDialog(QDialog):
         
         self.cancel_btn = QPushButton("Close")
         self.cancel_btn.clicked.connect(self.reject)
+        
         button_layout.addWidget(self.export_btn)
         button_layout.addWidget(self.cancel_btn)
         
         layout.addLayout(button_layout)
     
-# === Folder and preview helpers ===
+    # === UI Event Handlers ===
+    
     def _browse_output_folder(self):
+        """Browse for output folder"""
         folder = QFileDialog.getExistingDirectory(self, "Select Export Folder")
         if folder:
             self.folder_edit.setText(folder)
-            self._update_filename_preview()
-
+    
     def _on_use_input_folder_changed(self, state):
+        """Handle use input folder checkbox change"""
         use_input = self.use_input_folder_checkbox.isChecked()
         self.folder_edit.setEnabled(not use_input)
         self.browse_btn.setEnabled(not use_input)
         self._update_filename_preview()
-
-    def _get_available_object_ids(self):
-        """Get list of available object IDs from points"""
-        if self.parent_window and hasattr(self.parent_window, 'point_manager'):
-            points = self.parent_window.point_manager.get_all_points()
-            if points:
-                return sorted(set(point['object_id'] for point in points))
-        return []
     
-    def _resolve_filename_template(self, template, object_id=None):
-        """Replace tags with actual values for preview/usage"""
-        settings_mgr = self.parent_window.settings_mgr
-        total_frames = sammie.VideoInfo.total_frames
-        input_file = settings_mgr.get_session_setting("video_file_path", "")
-        base_name = os.path.splitext(os.path.basename(input_file))[0] if input_file else "video"
-        input_ext = os.path.splitext(input_file)[1] if input_file else ""
-        input_path = os.path.dirname(input_file) if input_file else ""
-        in_point = settings_mgr.get_session_setting("in_point")
-        out_point = settings_mgr.get_session_setting("out_point")
-        if in_point is None:
-            in_point = 0
-        if out_point is None:
-            out_point = total_frames - 1
+    def _insert_tag(self, index):
+        """Insert template tag at cursor position"""
+        if index <= 0:
+            return
         
-        now = datetime.datetime.now()
-
-        # Use provided object_id or get from combo box
-        if object_id is not None:
-            selected_object_id = object_id
+        tag = self.tag_dropdown.itemText(index)
+        cursor_pos = self.filename_template_edit.cursorPosition()
+        text = self.filename_template_edit.text()
+        new_text = text[:cursor_pos] + tag + text[cursor_pos:]
+        self.filename_template_edit.setText(new_text)
+        self.filename_template_edit.setCursorPosition(cursor_pos + len(tag))
+        self.tag_dropdown.setCurrentIndex(0)
+    
+    def _on_format_changed(self, index):
+        """Handle format selection change"""
+        format_id = self.format_combo.itemData(index)
+        self.current_format = FormatRegistry.get_format(format_id)
+        
+        if not self.current_format:
+            return
+        
+        # Update output type combo
+        current_output = self.output_type_combo.currentText()
+        self.output_type_combo.clear()
+        self.output_type_combo.addItems(self.current_format.get_available_output_types())
+        
+        # Restore selection if valid
+        new_index = self.output_type_combo.findText(current_output)
+        if new_index >= 0:
+            self.output_type_combo.setCurrentIndex(new_index)
+        
+        # Update UI visibility based on format capabilities
+        self._update_ui_for_format()
+        self._update_filename_preview()
+    
+    def _on_output_type_changed(self):
+        """Handle output type change"""
+        output_type = self.output_type_combo.currentText()
+        is_object_removal = output_type == 'ObjectRemoval'
+        
+        # ObjectRemoval always uses all objects
+        if is_object_removal:
+            self.object_id_combo.setCurrentIndex(0)  # Set to "All Objects"
+            self.object_id_combo.setEnabled(False)
+            self.export_multiple_checkbox.setVisible(False)
+            self.export_multiple_checkbox.setChecked(False)
         else:
-            selected_object_id = self.object_id_combo.currentData() if self.object_id_combo else -1
-
-        # Get object name from session settings and sanitize it
-        object_names = settings_mgr.get_session_setting("object_names", {})
-        if selected_object_id != -1:
-            raw_object_name = object_names.get(str(selected_object_id), "")
-            # Provide default name if empty
-            if not raw_object_name.strip():
-                raw_object_name = f"object_{selected_object_id}"
-            sanitized_object_name = self._sanitize_filename_component(raw_object_name)
+            # Re-enable based on format capabilities
+            if self.current_format and self.current_format.is_sequence and self.current_format.format_id == 'exr':
+                # EXR sequences always export all objects as layers
+                self.object_id_combo.setEnabled(False)
+            else:
+                self.object_id_combo.setEnabled(not self.export_multiple_checkbox.isChecked())
+            
+            # Show multiple export checkbox if format supports it
+            if self.current_format and self.current_format.supports_multiple_export:
+                self.export_multiple_checkbox.setVisible(True)
+        
+        self._update_antialias_visibility()
+        self._update_filename_preview()
+    
+    def _update_ui_for_format(self):
+        """Update UI controls based on current format"""
+        if not self.current_format:
+            return
+        
+        # Quality setting
+        show_quality = self.current_format.supports_quality_setting
+        self.quantizer_spin.setVisible(show_quality)
+        self.quantizer_label.setVisible(show_quality)
+        
+        if show_quality:
+            min_q, max_q = self.current_format.get_quality_range()
+            self.quantizer_spin.setRange(min_q, max_q)
+            self.quantizer_spin.setValue(self.current_format.get_default_quality())
+            self.quantizer_label.setText(self.current_format.get_quality_label())
+        
+        # Multiple export
+        show_multiple = self.current_format.supports_multiple_export
+        self.export_multiple_checkbox.setVisible(show_multiple)
+        if not show_multiple:
+            self.export_multiple_checkbox.setChecked(False)
+        
+        # Include original
+        show_include_original = self.current_format.supports_include_original
+        self.include_original_checkbox.setVisible(show_include_original)
+        
+        # Object selection - check output type as well
+        output_type = self.output_type_combo.currentText()
+        is_object_removal = output_type == 'ObjectRemoval'
+        is_sequence = self.current_format.is_sequence
+        
+        if is_object_removal or (is_sequence and self.current_format.format_id == 'exr'):
+            # ObjectRemoval and EXR always use all objects
+            self.object_id_combo.setCurrentIndex(0)
+            self.object_id_combo.setEnabled(False)
         else:
-            sanitized_object_name = "all"
-
-        tag_values = {
-            "input_name": base_name,
-            "input_ext": input_ext,
-            "input_path": input_path,
-            "output_type": self.output_type_combo.currentText() if self.output_type_combo else "",
-            "codec": self.codec_combo.currentText() if self.codec_combo else "",
-            "object_id": str(selected_object_id) if selected_object_id != -1 else "all",
-            "object_name": sanitized_object_name,
-            "in_point": str(in_point),
-            "out_point": str(out_point),
-            "date": now.strftime("%Y%m%d"),
-            "time": now.strftime("%H%M%S"),
-            "datetime": now.strftime("%Y%m%d_%H%M%S"),
-        }
-
-        result = template
-        for tag, value in tag_values.items():
-            result = result.replace(f"{{{tag}}}", value)
-        return result
+            self.object_id_combo.setEnabled(not self.export_multiple_checkbox.isChecked())
+        
+        # Hide multiple export for ObjectRemoval
+        if is_object_removal:
+            self.export_multiple_checkbox.setVisible(False)
+            self.export_multiple_checkbox.setChecked(False)
+        
+        # Antialiasing (only for segmentation modes)
+        self._update_antialias_visibility()
+    
+    def _update_antialias_visibility(self):
+        """Update antialiasing checkbox visibility"""
+        output_type = self.output_type_combo.currentText()
+        is_segmentation = output_type.startswith('Segmentation-')
+        self.antialias_checkbox.setVisible(is_segmentation)
+    
+    def _on_export_multiple_changed(self, state):
+        """Handle export multiple checkbox change"""
+        export_multiple = self.export_multiple_checkbox.isChecked()
+        self.object_id_combo.setEnabled(not export_multiple)
+        self._update_filename_preview()
     
     def _update_filename_preview(self):
-        """Update filename preview based on current settings"""
-        template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
-
-        # Extension from codec
-        codec = self.codec_combo.currentText()
-        if codec == 'prores':
-            ext = '.mov'
-        elif codec == 'ffv1':
-            ext = '.mkv'
-        elif codec == 'vp9':
-            ext = '.webm'
-        elif codec == 'exr':
-            ext = '.####.exr'  # Frame sequence pattern
-        else:
-            ext = '.mp4'
+        """Update filename preview label"""
+        if not self.current_format or not self.path_manager:
+            return
         
+        template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
+        output_type = self.output_type_combo.currentText()
+        
+        # Get output directory
         if self.use_input_folder_checkbox.isChecked():
-            settings_mgr = self.parent_window.settings_mgr
-            input_file = settings_mgr.get_session_setting("video_file_path", "")
+            input_file = self.parent_window.settings_mgr.get_session_setting("video_file_path", "")
             folder = os.path.dirname(input_file) if input_file else os.getcwd()
         else:
             folder = self.folder_edit.text() or os.getcwd()
         
-        # Special handling for EXR sequences
-        if codec == 'exr':
-            resolved_name = self._resolve_filename_template(template)
-            preview_text = f"{folder}/{resolved_name}{ext}"
-            self.filename_preview_label.setText(preview_text)
-            return os.path.join(folder, resolved_name)  # Return base name without extension for EXR
-        
-        if self.export_multiple_checkbox.isChecked():
-            # Show preview for multiple files
+        # Generate preview
+        if self.current_format.is_sequence:
+            # Sequence preview
+            base_path = self.path_manager.generate_output_path(
+                folder, template, self.current_format.format_id, output_type
+            )
+            preview = f"{base_path}{self.current_format.file_extension}"
+            self.filename_preview_label.setText(preview)
+        elif self.export_multiple_checkbox.isChecked():
+            # Multiple file preview
             object_ids = self._get_available_object_ids()
             if object_ids:
-                # Show preview for first few objects
                 preview_files = []
-                for i, obj_id in enumerate(object_ids[:3]):  # Show first 3 as examples
-                    resolved_name = self._resolve_filename_template(template, obj_id)
-                    full_path = os.path.join(folder, resolved_name + ext)
-                    preview_files.append(os.path.basename(full_path))
+                for i, obj_id in enumerate(object_ids[:3]):
+                    path = self.path_manager.generate_output_path(
+                        folder, template, self.current_format.format_id, output_type, obj_id
+                    )
+                    preview_files.append(os.path.basename(path))
                 
                 preview_text = "\n".join(preview_files)
                 if len(object_ids) > 3:
                     preview_text += f"\n... and {len(object_ids) - 3} more files"
-                
                 self.filename_preview_label.setText(preview_text)
-                return os.path.join(folder, self._resolve_filename_template(template, object_ids[0]) + ext)
             else:
                 self.filename_preview_label.setText("No objects found")
-                return ""
         else:
             # Single file preview
-            resolved_name = self._resolve_filename_template(template)
-            full_path = os.path.join(folder, resolved_name + ext)
-            self.filename_preview_label.setText(full_path)
-            return full_path
+            object_id = self.object_id_combo.currentData()
+            path = self.path_manager.generate_output_path(
+                folder, template, self.current_format.format_id, output_type, object_id
+            )
+            self.filename_preview_label.setText(path)
     
-    def _on_codec_changed(self, codec):
-        """Handle codec selection changes"""
-        is_x264_x265 = codec in ['x264', 'x265']
-        is_vp9 = codec == 'vp9'
-        is_exr = codec == 'exr'
+    # === Export Logic ===
+    
+    def _start_export(self):
+        """Start the export process"""
+        if not self._validate_settings():
+            return
         
-        # Show/hide quantizer setting based on codec
-        self.quantizer_spin.setVisible(is_x264_x265 or is_vp9)
-        self.quantizer_label.setVisible(is_x264_x265 or is_vp9)
+        # Build export settings
+        settings = self._build_export_settings()
         
-        # Adjust quantizer range for VP9 (0-63 instead of 0-51)
-        if is_vp9:
-            self.quantizer_spin.setRange(0, 63)
-            self.quantizer_spin.setValue(14)  # Default CQ level for VP9
-            self.quantizer_label.setText("Quality (CQ):")
-        elif is_x264_x265:
-            self.quantizer_spin.setRange(0, 51)
-            self.quantizer_spin.setValue(14)
-            self.quantizer_label.setText("Quality (CRF):")
-
-        # Handle Alpha option availability
-        current_output_type = self.output_type_combo.currentText()
+        # Get points
+        points = self.parent_window.point_manager.get_all_points()
+        total_frames = sammie.VideoInfo.total_frames
         
-        # Store current alpha types
-        alpha_types = ['Segmentation-Alpha', 'Matting-Alpha']
+        # Generate output paths
+        output_paths, object_ids = self._generate_output_paths(settings)
         
-        if (is_x264_x265 or is_exr):
-            # Remove alpha options if present
-            for alpha_type in alpha_types:
-                alpha_index = self.output_type_combo.findText(alpha_type)
-                if alpha_index >= 0:
-                    # If an Alpha type is currently selected, switch to corresponding Matte first
-                    if current_output_type == alpha_type:
-                        if alpha_type == 'Segmentation-Alpha':
-                            matte_index = self.output_type_combo.findText('Segmentation-Matte')
-                        else:  # Matting-Alpha
-                            matte_index = self.output_type_combo.findText('Matting-Matte')
-                        
-                        if matte_index >= 0:
-                            self.output_type_combo.setCurrentIndex(matte_index)
-                    
-                    # Remove the alpha option
-                    self.output_type_combo.removeItem(alpha_index)
+        # Create appropriate worker
+        if self.current_format.is_sequence:
+            base_filename = os.path.basename(output_paths[0])
+            self.export_worker = SequenceExportWorker(
+                settings, points, total_frames, base_filename, self.parent_window
+            )
         else:
-            # Re-add alpha options if they're missing (maintaining proper order)
-            all_types = [
-                'Segmentation-Matte', 'Segmentation-Alpha', 'Segmentation-BGcolor',
-                'Matting-Matte', 'Matting-Alpha', 'Matting-BGcolor', 'ObjectRemoval'
-            ]
-            
-            # Check which alpha types are missing and add them in correct positions
-            for i, type_name in enumerate(all_types):
-                if type_name in alpha_types and self.output_type_combo.findText(type_name) == -1:
-                    self.output_type_combo.insertItem(i, type_name)
-
-        # Show/hide warning label
-        self.alpha_warning_label.setVisible(is_x264_x265)
-
-        # EXR-specific UI changes
-        if is_exr:
-            # For EXR, only allow Segmentation-Matte and Matting-Matte options
-            allowed_types = ['Segmentation-Matte', 'Matting-Matte']
-            
-            # Save current selection if it's allowed
-            current_selection = self.output_type_combo.currentText()
-            
-            # Clear and rebuild combo with only allowed options
-            self.output_type_combo.clear()
-            self.output_type_combo.addItems(allowed_types)
-            
-            # Restore selection if it was allowed, otherwise default to Segmentation-Matte
-            if current_selection in allowed_types:
-                index = self.output_type_combo.findText(current_selection)
-                if index >= 0:
-                    self.output_type_combo.setCurrentIndex(index)
-            else:
-                # Default to Segmentation-Matte
-                self.output_type_combo.setCurrentIndex(0)
-            
-            # Keep output type combo enabled for EXR
-            self.output_type_combo.setEnabled(True)
-            
-            # Force All Objects and disable object selection
-            self.object_id_combo.setCurrentIndex(0)  # All Objects
-            self.object_id_combo.setEnabled(False)
-            
-            # Hide export multiple checkbox
-            self.export_multiple_checkbox.setVisible(False)
-            self.export_multiple_checkbox.setChecked(False)
-            
-            # Show include original checkbox
-            self.include_original_checkbox.setVisible(True)
-            
-            # Update label text to indicate frame sequence
-            if hasattr(self, 'filename_preview_label'):
-                current_text = self.filename_preview_label.text()
-                if current_text and not "Frame sequence:" in current_text:
-                    self.filename_preview_label.setText(f"Frame sequence: {current_text}")
-        else:
-            # Re-enable controls for non-EXR codecs and restore full options
-            all_types = [
-                'Segmentation-Matte', 'Segmentation-Alpha', 'Segmentation-BGcolor',
-                'Matting-Matte', 'Matting-Alpha', 'Matting-BGcolor', 'ObjectRemoval'
-            ]
-            
-            # Save current selection
-            current_selection = self.output_type_combo.currentText()
-            
-            # Rebuild combo with all options (excluding alpha if x264/x265)
-            self.output_type_combo.clear()
-            for type_name in all_types:
-                if not (is_x264_x265 and 'Alpha' in type_name):
-                    self.output_type_combo.addItem(type_name)
-            
-            # Restore selection or use default
-            index = self.output_type_combo.findText(current_selection)
-            if index >= 0:
-                self.output_type_combo.setCurrentIndex(index)
-            
-            self.output_type_combo.setEnabled(True)
-            self.object_id_combo.setEnabled(not self.export_multiple_checkbox.isChecked())
-            self.export_multiple_checkbox.setVisible(True)
-            self.include_original_checkbox.setVisible(False)
-            
-        self._update_filename_preview()
+            self.export_worker = VideoExportWorker(
+                settings, points, total_frames, output_paths, object_ids, self.parent_window
+            )
+        
+        # Connect signals
+        self.export_worker.progress_updated.connect(self._update_progress)
+        self.export_worker.status_updated.connect(self._update_status)
+        self.export_worker.finished.connect(self._export_finished)
+        
+        # Create progress dialog
+        initial_text = self._get_initial_progress_text(settings, output_paths)
+        self.progress_dialog = QProgressDialog(initial_text, "Cancel", 0, 100, self)
+        self.progress_dialog.setWindowTitle("Exporting")
+        self.progress_dialog.setWindowModality(Qt.WindowModal)
+        self.progress_dialog.setAutoClose(False)
+        self.progress_dialog.canceled.connect(self._cancel_export)
+        self.progress_dialog.show()
+        
+        # Disable export button
+        self.export_btn.setEnabled(False)
+        
+        # Start export
+        self.export_worker.start()
     
-    def _sanitize_filename_component(self, name):
-        """Sanitize name for use in filenames"""
-        import re
-        if not name:
-            return ""
-        # Replace spaces and special characters with underscores
-        sanitized = re.sub(r'[^\w]', '_', name)
-        # Remove multiple consecutive underscores
-        sanitized = re.sub(r'_+', '_', sanitized)
-        # Remove leading/trailing underscores
-        sanitized = sanitized.strip('_')
-        # Limit length to reasonable size
-        if len(sanitized) > 20:
-            sanitized = sanitized[:20]
-        return sanitized if sanitized else "unnamed"
-    
-    def _validate_settings(self):
-        """Validate export settings"""
-        # Check output directory
+    def _build_export_settings(self) -> ExportSettings:
+        """Build export settings from UI"""
+        # Get in/out points
+        use_inout = self.use_inout_checkbox.isChecked()
+        in_point = None
+        out_point = None
+        
+        if use_inout and self.parent_window:
+            settings_mgr = self.parent_window.settings_mgr
+            in_point = settings_mgr.get_session_setting("in_point", None)
+            out_point = settings_mgr.get_session_setting("out_point", None)
+        
+        # Get output directory
         if self.use_input_folder_checkbox.isChecked():
-            if self.parent_window and hasattr(self.parent_window, 'settings_mgr'):
-                settings_mgr = self.parent_window.settings_mgr
-                input_file = settings_mgr.get_session_setting("video_file_path", "")
-                folder = os.path.dirname(input_file) if input_file else ""
-                if not folder or not os.path.exists(folder):
-                    show_message_dialog(self, title="Invalid Settings" , message="Input file directory is not available. Please select an output folder manually.", type="warning")
-                    return False
-            else:
-                msg_box = QMessageBox(self)
-                show_message_dialog(self, title="Invalid Settings" , message="Cannot determine input file location. Please select an output folder manually.", type="warning")
+            input_file = self.parent_window.settings_mgr.get_session_setting("video_file_path", "")
+            output_dir = os.path.dirname(input_file) if input_file else os.getcwd()
+        else:
+            output_dir = self.folder_edit.text() or os.getcwd()
+        
+        return ExportSettings(
+            format_id=self.current_format.format_id,
+            output_dir=output_dir,
+            filename_template=self.filename_template_edit.text().strip() or "{input_name}-{output_type}",
+            output_type=self.output_type_combo.currentText(),
+            object_id=self.object_id_combo.currentData(),
+            antialias=self.antialias_checkbox.isChecked(),
+            quality=self.quantizer_spin.value(),
+            use_inout=use_inout,
+            in_point=in_point,
+            out_point=out_point,
+            include_original=self.include_original_checkbox.isChecked(),
+            export_multiple=self.export_multiple_checkbox.isChecked()
+        )
+    
+    def _generate_output_paths(self, settings: ExportSettings) -> tuple:
+        """Generate output paths and corresponding object IDs"""
+        output_paths = []
+        object_ids = []
+        
+        if settings.export_multiple:
+            # Multiple files for different objects
+            all_object_ids = self._get_available_object_ids()
+            for obj_id in all_object_ids:
+                path = self.path_manager.generate_output_path(
+                    settings.output_dir, settings.filename_template,
+                    settings.format_id, settings.output_type, obj_id
+                )
+                output_paths.append(path)
+                object_ids.append(obj_id)
+        else:
+            # Single file
+            path = self.path_manager.generate_output_path(
+                settings.output_dir, settings.filename_template,
+                settings.format_id, settings.output_type, settings.object_id
+            )
+            output_paths.append(path)
+            object_ids.append(settings.object_id)
+        
+        return output_paths, object_ids
+    
+    def _validate_settings(self) -> bool:
+        """Validate export settings"""
+        # Validate output directory
+        if not self._validate_output_directory():
+            return False
+        
+        # Validate template for multiple export
+        if self.export_multiple_checkbox.isChecked():
+            template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
+            if "{object_id}" not in template and "{object_name}" not in template:
+                show_message_dialog(
+                    self, title="Invalid Settings",
+                    message="When exporting separate files for each object, filename must include either {object_id} or {object_name} tag.",
+                    type='warning'
+                )
+                return False
+        
+        # Check for existing files
+        settings = self._build_export_settings()
+        output_paths, _ = self._generate_output_paths(settings)
+        
+        if self.current_format.is_sequence:
+            # For sequences, check if any frame files exist
+            existing = self._check_sequence_files_exist(output_paths[0], settings)
+            if existing:
+                return self._confirm_overwrite_sequence(existing, settings)
+        else:
+            # For video, check file existence
+            existing = self.path_manager.check_existing_files(output_paths)
+            if existing:
+                return self._confirm_overwrite_files(existing)
+        
+        return True
+    
+    def _validate_output_directory(self) -> bool:
+        """Validate and create output directory if needed"""
+        if self.use_input_folder_checkbox.isChecked():
+            input_file = self.parent_window.settings_mgr.get_session_setting("video_file_path", "")
+            folder = os.path.dirname(input_file) if input_file else ""
+            if not folder or not os.path.exists(folder):
+                show_message_dialog(
+                    self, title="Invalid Settings",
+                    message="Input file directory is not available. Please select an output folder manually.",
+                    type="warning"
+                )
                 return False
         else:
             folder = self.folder_edit.text().strip()
             if not folder:
-                show_message_dialog(self, title="Invalid Settings" , message="Please select an output folder.", type="warning")
+                show_message_dialog(
+                    self, title="Invalid Settings",
+                    message="Please select an output folder.",
+                    type="warning"
+                )
                 return False
-            # Prompt to create folder if it doesn't exist
+            
             if not os.path.exists(folder):
                 reply = QMessageBox.question(
                     self, "Create Folder?",
@@ -1057,304 +617,94 @@ class ExportDialog(QDialog):
                 try:
                     os.makedirs(folder, exist_ok=True)
                 except OSError as e:
-                    show_message_dialog(self, title="Invalid Settings" , message=f"Could not create output directory:\n{e}", type="warning")
+                    show_message_dialog(
+                        self, title="Error",
+                        message=f"Could not create output directory:\n{e}",
+                        type="critical"
+                    )
                     return False
         
-        template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
-    
-        if "{object_name}" in template:
-            # Check if we have object names available
-            object_names = {}
-            if hasattr(self.parent_window, 'settings_mgr'):
-                object_names = self.parent_window.settings_mgr.get_session_setting("object_names", {})
-            
-            # Get object IDs that will be exported
-            if self.export_multiple_checkbox.isChecked():
-                object_ids = self._get_available_object_ids()
-            else:
-                selected_object_data = self.object_id_combo.currentData()
-                object_ids = [selected_object_data] if selected_object_data != -1 else self._get_available_object_ids()
-        
-        # EXR-specific validation
-        codec = self.codec_combo.currentText()
-        if codec == 'exr':
-            
-            # Check for objects
-            object_ids = self._get_available_object_ids()
-            if not object_ids:
-                show_message_dialog(self, title="No Objects", message="No objects found to export.", type='warning')
-                return False
-            
-            # Check for existing files
-            template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
-            resolved_name = self._resolve_filename_template(template)
-            
-            if self.use_input_folder_checkbox.isChecked():
-                settings_mgr = self.parent_window.settings_mgr
-                input_file = settings_mgr.get_session_setting("video_file_path", "")
-                folder = os.path.dirname(input_file) if input_file else os.getcwd()
-            else:
-                folder = self.folder_edit.text() or os.getcwd()
-            
-            # Check if any EXR files with this pattern exist
-            existing_files = []
-            total_frames = sammie.VideoInfo.total_frames
-            for frame_num in range(min(5, total_frames)):  # Check first 5 frames
-                frame_filename = f"{resolved_name}.{frame_num:04d}.exr"
-                frame_path = os.path.join(folder, frame_filename)
-                if os.path.exists(frame_path):
-                    existing_files.append(frame_filename)
-            
-            if existing_files:
-                files_text = "\n".join(existing_files)
-                if len(existing_files) == 5 and total_frames > 5:
-                    files_text += f"\n... (and possibly {total_frames - 5} more)"
-                
-                reply = QMessageBox.question(
-                    self, "EXR Files Exist",
-                    f"EXR files with this naming pattern already exist:\n\n{files_text}\n\nDo you want to overwrite them?",
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No
-                )
-                if reply != QMessageBox.Yes:
-                    return False
-            
-            return True
-        
-        # Special validation for multiple export mode
-        if self.export_multiple_checkbox.isChecked():
-            template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
-            
-            # Check if either {object_id} or {object_name} tag is included
-            has_object_id = "{object_id}" in template
-            has_object_name = "{object_name}" in template
-            
-            if not has_object_id and not has_object_name:
-                show_message_dialog(self, title="Invalid Settings", message="When exporting videos for each object, filename must include either {object_id} or {object_name} tag to avoid overwriting files.", type='warning')
-                return False
-            
-            # Check for existing files and confirm overwrite
-            object_ids = self._get_available_object_ids()
-            if not object_ids:
-                show_message_dialog(self, title="No Objects", message="No objects found to export.", type='warning')
-                return False
-            
-            existing_files = []
-            for obj_id in object_ids:
-                output_path = self._generate_output_path_for_object(obj_id)
-                if os.path.exists(output_path):
-                    existing_files.append(os.path.basename(output_path))
-            
-            if existing_files:
-                files_text = "\n".join(existing_files[:5])  # Show first 5
-                if len(existing_files) > 5:
-                    files_text += f"\n... and {len(existing_files) - 5} more files"
-                
-                reply = QMessageBox.question(
-                    self, "Files Exist",
-                    f"The following files already exist and will be overwritten:\n\n{files_text}\n\nDo you want to continue?",
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No
-                )
-                if reply != QMessageBox.Yes:
-                    return False
-        else:
-            # Single file validation (existing logic)
-            output_path = self._update_filename_preview()
-            if os.path.exists(output_path):
-                reply = QMessageBox.question(
-                    self, "File Exists",
-                    f"The file '{os.path.basename(output_path)}' already exists.\n\nDo you want to overwrite it?",
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No
-                )
-                if reply != QMessageBox.Yes:
-                    return False
-
         return True
-
-    def _generate_output_path_for_object(self, object_id):
-        """Generate full output path for a specific object ID"""
-        template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
-        resolved_name = self._resolve_filename_template(template, object_id)
-        
-        # Extension from codec
-        codec = self.codec_combo.currentText()
-        if codec == 'prores':
-            ext = '.mov'
-        elif codec == 'ffv1':
-            ext = '.mkv'
-        else:
-            ext = '.mp4'
-        
-        if self.use_input_folder_checkbox.isChecked():
-            settings_mgr = self.parent_window.settings_mgr
-            input_file = settings_mgr.get_session_setting("video_file_path", "")
-            folder = os.path.dirname(input_file) if input_file else os.getcwd()
-        else:
-            folder = self.folder_edit.text() or os.getcwd()
-        
-        return os.path.join(folder, resolved_name + ext)
     
-    def _start_export(self):
-        """Start the export process"""
-        if not self._validate_settings():
-            return
-
-        # Get in/out points from session settings
-        settings_mgr = self.parent_window.settings_mgr if self.parent_window else None
-        in_point = None
-        out_point = None
-        use_inout = self.use_inout_checkbox.isChecked()
-        
-        if use_inout and settings_mgr:
-            in_point = settings_mgr.get_session_setting("in_point", None)
-            out_point = settings_mgr.get_session_setting("out_point", None)
-        
-        # Calculate actual frame range
+    def _check_sequence_files_exist(self, base_path: str, settings: ExportSettings) -> list:
+        """Check if sequence files exist"""
+        existing_files = []
         total_frames = sammie.VideoInfo.total_frames
-        if use_inout and in_point is not None and out_point is not None:
-            start_frame = max(0, in_point)
-            end_frame = min(total_frames - 1, out_point)
-            export_frame_count = end_frame - start_frame + 1
+        
+        # Determine frame range
+        if settings.use_inout and settings.in_point is not None and settings.out_point is not None:
+            start_frame = max(0, settings.in_point)
+            end_frame = min(total_frames - 1, settings.out_point)
         else:
             start_frame = 0
             end_frame = total_frames - 1
-            export_frame_count = total_frames
         
-        # ensure in/out points are valid for use later on
-        if in_point is None:
-            in_point = 0
-        if out_point is None:
-            out_point = total_frames - 1
+        # Check first few frames
+        for frame_num in range(start_frame, min(start_frame + 5, end_frame + 1)):
+            if self.current_format.format_id == 'exr':
+                frame_file = f"{base_path}.{frame_num:04d}.exr"
+            else:  # PNG
+                frame_file = f"{base_path}.{frame_num:04d}.png"
             
-        # Get codec
-        codec = self.codec_combo.currentText()
+            if os.path.exists(frame_file):
+                existing_files.append(os.path.basename(frame_file))
         
-        # Get points
-        points = self.parent_window.point_manager.get_all_points()
-
-        if export_frame_count == 0:
-            show_message_dialog(self, title="Export Error", message="No frames in export range.", type='warning')
-            return
+        return existing_files
+    
+    def _confirm_overwrite_sequence(self, existing_files: list, settings: ExportSettings) -> bool:
+        """Confirm overwriting sequence files"""
+        files_text = "\n".join(existing_files)
         
-        # Determine export mode and parameters
-        export_multiple = self.export_multiple_checkbox.isChecked()
-        
-        if codec == 'exr':
-            # EXR export mode
-            template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
-            resolved_name = self._resolve_filename_template(template)
-            
-            if self.use_input_folder_checkbox.isChecked():
-                input_file = settings_mgr.get_session_setting("video_file_path", "")
-                folder = os.path.dirname(input_file) if input_file else os.getcwd()
-            else:
-                folder = self.folder_edit.text() or os.getcwd()
-            
-            export_params = {
-                'output_path': folder,
-                'base_filename': resolved_name,
-                'codec': 'exr',
-                'output_type': self.output_type_combo.currentText(),
-                'antialias': self.antialias_checkbox.isChecked(),
-                'include_original': self.include_original_checkbox.isChecked(),
-                'object_id': -1,  # Always all objects for EXR
-                'use_inout': use_inout,
-                'in_point': in_point,
-                'out_point': out_point
-            }
-            
-            # Create worker for EXR export
-            self.export_worker = ExportWorker(export_params, points, total_frames, parent_window=self.parent_window)
-            
-        elif export_multiple:
-            # Multiple object export
-            object_ids = self._get_available_object_ids()
-            if not object_ids:
-                show_message_dialog(self, title="No Objects", message="No objects found to export", type="warning")
-                return
-            
-            # Get folder path
-            if self.use_input_folder_checkbox.isChecked():
-                input_file = settings_mgr.get_session_setting("video_file_path", "")
-                folder = os.path.dirname(input_file) if input_file else os.getcwd()
-                input_name = os.path.splitext(os.path.basename(input_file))[0] if input_file else "video"
-            else:
-                folder = self.folder_edit.text() or os.getcwd()
-                input_file = settings_mgr.get_session_setting("video_file_path", "")
-                input_name = os.path.splitext(os.path.basename(input_file))[0] if input_file else "video"
-            
-            # Get filename template
-            template = self.filename_template_edit.text().strip() or "{input_name}-{output_type}"
-            
-            object_names = {}
-            if hasattr(self.parent_window, 'settings_mgr'):
-                object_names = self.parent_window.settings_mgr.get_session_setting("object_names", {})
-            
-            export_params = {
-                'output_path': folder,  # Just the directory for multiple export
-                'filename_template': template,
-                'codec': self.codec_combo.currentText(),
-                'output_type': self.output_type_combo.currentText(),
-                'antialias': self.antialias_checkbox.isChecked(),
-                'quantizer': self.quantizer_spin.value(),
-                'object_id': -1,  # Will be set per object by worker
-                'object_names': object_names,
-                'input_name': input_name,
-                'use_inout': use_inout,
-                'in_point': in_point,
-                'out_point': out_point
-            }
-            
-            # Create worker for multiple export
-            self.export_worker = ExportWorker(export_params, points, total_frames, export_multiple=True, 
-                                              object_ids=object_ids, parent_window=self.parent_window)
+        # Calculate total frames
+        total_frames = sammie.VideoInfo.total_frames
+        if settings.use_inout and settings.in_point is not None and settings.out_point is not None:
+            frame_count = settings.out_point - settings.in_point + 1
         else:
-            # Single export (existing logic)
-            selected_object_data = self.object_id_combo.currentData()
-            output_path = self._update_filename_preview()
-            export_params = {
-                'output_path': output_path,
-                'codec': self.codec_combo.currentText(),
-                'output_type': self.output_type_combo.currentText(),
-                'antialias': self.antialias_checkbox.isChecked(),
-                'quantizer': self.quantizer_spin.value(),
-                'object_id': selected_object_data,  # -1 for all objects, specific ID for single object
-                'use_inout': use_inout,
-                'in_point': in_point,
-                'out_point': out_point
-            }
-            
-            # Create worker for single export
-            self.export_worker = ExportWorker(export_params, points, total_frames, parent_window=self.parent_window)
+            frame_count = total_frames
         
-        # Connect worker signals
-        self.export_worker.progress_updated.connect(self._update_progress)
-        self.export_worker.status_updated.connect(self._update_status)
-        self.export_worker.finished.connect(self._export_finished)
+        if len(existing_files) == 5 and frame_count > 5:
+            files_text += f"\n... (and possibly {frame_count - 5} more)"
         
-        # Create progress dialog
-        if codec == 'exr':
-            initial_text = f"Exporting {export_frame_count} EXR frames..."
-        elif export_multiple:
-            object_ids = self._get_available_object_ids()
-            initial_text = f"Exporting {len(object_ids)} videos..."
+        reply = QMessageBox.question(
+            self, "Files Exist",
+            f"Sequence files already exist:\n\n{files_text}\n\nDo you want to overwrite them?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No
+        )
+        return reply == QMessageBox.Yes
+    
+    def _confirm_overwrite_files(self, existing_files: list) -> bool:
+        """Confirm overwriting video files"""
+        if len(existing_files) == 1:
+            message = f"The file '{os.path.basename(existing_files[0])}' already exists.\n\nDo you want to overwrite it?"
         else:
-            initial_text = "Exporting video..."
-            
-        self.progress_dialog = QProgressDialog(initial_text, "Cancel", 0, 100, self)
-        self.progress_dialog.setWindowTitle("Exporting Video" if codec != 'exr' else "Exporting EXR Sequence")
-        self.progress_dialog.setWindowModality(Qt.WindowModal)
-        self.progress_dialog.setAutoClose(False)
-        self.progress_dialog.canceled.connect(self._cancel_export)
-        self.progress_dialog.show()
+            files_text = "\n".join([os.path.basename(f) for f in existing_files[:5]])
+            if len(existing_files) > 5:
+                files_text += f"\n... and {len(existing_files) - 5} more files"
+            message = f"The following files already exist:\n\n{files_text}\n\nDo you want to overwrite them?"
         
-        # Disable dialog controls during export
-        self.export_btn.setEnabled(False)
-        
-        # Start export
-        self.export_worker.start()
+        reply = QMessageBox.question(
+            self, "Files Exist", message,
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No
+        )
+        return reply == QMessageBox.Yes
+    
+    def _get_initial_progress_text(self, settings: ExportSettings, output_paths: list) -> str:
+        """Get initial progress dialog text"""
+        if self.current_format.is_sequence:
+            total_frames = sammie.VideoInfo.total_frames
+            if settings.use_inout and settings.in_point is not None and settings.out_point is not None:
+                frame_count = settings.out_point - settings.in_point + 1
+            else:
+                frame_count = total_frames
+            return f"Exporting {frame_count} {self.current_format.display_name} frames..."
+        elif len(output_paths) > 1:
+            return f"Exporting {len(output_paths)} videos..."
+        else:
+            return "Exporting video..."
+    
+    # === Progress Handling ===
     
     def _update_progress(self, value):
         """Update progress dialog"""
@@ -1373,12 +723,10 @@ class ExportDialog(QDialog):
     
     def _export_finished(self, success, message):
         """Handle export completion"""
-        # Clean up progress dialog
         if self.progress_dialog:
             self.progress_dialog.close()
             self.progress_dialog = None
         
-        # Re-enable controls
         self.export_btn.setEnabled(True)
         
         # Show completion message
@@ -1392,7 +740,9 @@ class ExportDialog(QDialog):
             self.export_worker.quit()
             self.export_worker.wait()
             self.export_worker = None
-            
+    
+    # === Settings Persistence ===
+    
     def _save_current_settings(self):
         """Save current dialog settings to application settings"""
         if not self.parent_window or not hasattr(self.parent_window, 'settings_mgr'):
@@ -1400,50 +750,73 @@ class ExportDialog(QDialog):
         
         settings_mgr = self.parent_window.settings_mgr
         
-        # Save current UI values to app settings
-        settings_mgr.set_app_setting('export_codec', self.codec_combo.currentText())
+        # Save current UI values
+        settings_mgr.set_app_setting('export_format_id', self.current_format.format_id)
         settings_mgr.set_app_setting('export_output_type', self.output_type_combo.currentText())
         settings_mgr.set_app_setting('export_use_input_folder', self.use_input_folder_checkbox.isChecked())
         settings_mgr.set_app_setting('export_filename_template', self.filename_template_edit.text())
         settings_mgr.set_app_setting('export_antialias', self.antialias_checkbox.isChecked())
-        settings_mgr.set_app_setting('export_quantizer', self.quantizer_spin.value())
+        settings_mgr.set_app_setting('export_quality', self.quantizer_spin.value())
         settings_mgr.set_app_setting('export_include_original', self.include_original_checkbox.isChecked())
         settings_mgr.set_app_setting('export_multiple', self.export_multiple_checkbox.isChecked())
         settings_mgr.set_app_setting('export_folder_path', self.folder_edit.text())
         settings_mgr.set_app_setting('export_use_inout', self.use_inout_checkbox.isChecked())
         
-        # Save to disk
         settings_mgr.save_app_settings()
-        
-        # Show confirmation
         QMessageBox.information(self, "Settings Saved", "Export settings have been saved as defaults.")
     
     def _load_saved_settings(self):
-        """Load previously saved settings from application settings"""
+        """Load previously saved settings"""
         if not self.parent_window or not hasattr(self.parent_window, 'settings_mgr'):
             return
         
         settings_mgr = self.parent_window.settings_mgr
         
-        # Load and apply saved settings
-        codec = settings_mgr.get_app_setting('export_codec', 'prores')
-        codec_index = self.codec_combo.findText(codec)
-        if codec_index >= 0:
-            self.codec_combo.setCurrentIndex(codec_index)
+        # Load format
+        format_id = settings_mgr.get_app_setting('export_format_id', 'prores')
+        for i in range(self.format_combo.count()):
+            if self.format_combo.itemData(i) == format_id:
+                self.format_combo.setCurrentIndex(i)
+                break
         
+        # Load other settings
         output_type = settings_mgr.get_app_setting('export_output_type', 'Segmentation-Matte')
         output_index = self.output_type_combo.findText(output_type)
         if output_index >= 0:
             self.output_type_combo.setCurrentIndex(output_index)
         
-        self.use_input_folder_checkbox.setChecked(settings_mgr.get_app_setting('export_use_input_folder', True))
-        self.filename_template_edit.setText(settings_mgr.get_app_setting('export_filename_template', '{input_name}-{output_type}'))
-        self.antialias_checkbox.setChecked(settings_mgr.get_app_setting('export_antialias', False))
-        self.quantizer_spin.setValue(settings_mgr.get_app_setting('export_quantizer', 14))
-        self.include_original_checkbox.setChecked(settings_mgr.get_app_setting('export_include_original', False))
-        self.export_multiple_checkbox.setChecked(settings_mgr.get_app_setting('export_multiple', False))
-        self.use_inout_checkbox.setChecked(settings_mgr.get_app_setting('export_use_inout', True))
+        self.use_input_folder_checkbox.setChecked(
+            settings_mgr.get_app_setting('export_use_input_folder', True)
+        )
+        self.filename_template_edit.setText(
+            settings_mgr.get_app_setting('export_filename_template', '{input_name}-{output_type}')
+        )
+        self.antialias_checkbox.setChecked(
+            settings_mgr.get_app_setting('export_antialias', False)
+        )
+        self.quantizer_spin.setValue(
+            settings_mgr.get_app_setting('export_quality', 14)
+        )
+        self.include_original_checkbox.setChecked(
+            settings_mgr.get_app_setting('export_include_original', False)
+        )
+        self.export_multiple_checkbox.setChecked(
+            settings_mgr.get_app_setting('export_multiple', False)
+        )
+        self.use_inout_checkbox.setChecked(
+            settings_mgr.get_app_setting('export_use_inout', True)
+        )
         
         folder_path = settings_mgr.get_app_setting('export_folder_path', '')
         if folder_path and os.path.exists(folder_path):
             self.folder_edit.setText(folder_path)
+    
+    # === Helper Methods ===
+    
+    def _get_available_object_ids(self) -> list:
+        """Get list of available object IDs from points"""
+        if self.parent_window and hasattr(self.parent_window, 'point_manager'):
+            points = self.parent_window.point_manager.get_all_points()
+            if points:
+                return sorted(set(point['object_id'] for point in points))
+        return []

--- a/sammie/export_formats.py
+++ b/sammie/export_formats.py
@@ -1,0 +1,503 @@
+# sammie/export_formats.py
+"""
+Export format definitions and configuration.
+Each format class encapsulates format-specific behavior.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Any
+import os
+
+
+@dataclass
+class ExportSettings:
+    """Unified export settings structure"""
+    format_id: str
+    output_dir: str
+    filename_template: str
+    output_type: str
+    object_id: int  # -1 for all objects
+    antialias: bool
+    quality: int  # CRF/CQ value for lossy codecs
+    use_inout: bool
+    in_point: Optional[int]
+    out_point: Optional[int]
+    include_original: bool = False  # EXR only
+    export_multiple: bool = False  # Video only
+
+
+class ExportFormat(ABC):
+    """Base class for export formats"""
+    
+    @property
+    @abstractmethod
+    def format_id(self) -> str:
+        """Unique identifier for this format"""
+        pass
+    
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        """Display name in UI"""
+        pass
+    
+    @property
+    @abstractmethod
+    def file_extension(self) -> str:
+        """File extension including dot"""
+        pass
+    
+    @property
+    @abstractmethod
+    def supports_alpha(self) -> bool:
+        """Whether format supports alpha channel"""
+        pass
+    
+    @property
+    @abstractmethod
+    def supports_quality_setting(self) -> bool:
+        """Whether format supports quality/CRF setting"""
+        pass
+    
+    @property
+    @abstractmethod
+    def supports_multiple_export(self) -> bool:
+        """Whether format supports exporting multiple objects as separate files"""
+        pass
+    
+    @property
+    @abstractmethod
+    def supports_include_original(self) -> bool:
+        """Whether format supports including original frames"""
+        pass
+    
+    @property
+    @abstractmethod
+    def is_sequence(self) -> bool:
+        """Whether this format exports frame sequences"""
+        pass
+    
+    @abstractmethod
+    def get_available_output_types(self) -> List[str]:
+        """Get list of valid output types for this format"""
+        pass
+    
+    @abstractmethod
+    def get_codec_name(self) -> Optional[str]:
+        """Get codec name for video formats (None for sequences)"""
+        pass
+    
+    @abstractmethod
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        """Get pixel format for encoding"""
+        pass
+    
+    @abstractmethod
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        """Get codec-specific options"""
+        pass
+    
+    def get_quality_label(self) -> str:
+        """Get label for quality setting"""
+        return "Quality (CRF):"
+    
+    def get_quality_range(self) -> tuple:
+        """Get min/max range for quality setting"""
+        return (0, 51)
+    
+    def get_default_quality(self) -> int:
+        """Get default quality value"""
+        return 14
+
+
+# === Video Formats ===
+
+class ProResFormat(ExportFormat):
+    @property
+    def format_id(self) -> str:
+        return "prores"
+    
+    @property
+    def display_name(self) -> str:
+        return "ProRes Video"
+    
+    @property
+    def file_extension(self) -> str:
+        return ".mov"
+    
+    @property
+    def supports_alpha(self) -> bool:
+        return True
+    
+    @property
+    def supports_quality_setting(self) -> bool:
+        return False
+    
+    @property
+    def supports_multiple_export(self) -> bool:
+        return True
+    
+    @property
+    def supports_include_original(self) -> bool:
+        return False
+    
+    @property
+    def is_sequence(self) -> bool:
+        return False
+    
+    def get_available_output_types(self) -> List[str]:
+        return [
+            'Segmentation-Matte', 'Segmentation-Alpha', 'Segmentation-BGcolor',
+            'Matting-Matte', 'Matting-Alpha', 'Matting-BGcolor', 'ObjectRemoval'
+        ]
+    
+    def get_codec_name(self) -> str:
+        return "prores_ks"
+    
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        return 'yuva444p10le' if has_alpha else 'yuv422p10le'
+    
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        return {'profile': '4' if self.supports_alpha else '3'}
+
+
+class FFV1Format(ExportFormat):
+    @property
+    def format_id(self) -> str:
+        return "ffv1"
+    
+    @property
+    def display_name(self) -> str:
+        return "FFV1 Video"
+    
+    @property
+    def file_extension(self) -> str:
+        return ".mkv"
+    
+    @property
+    def supports_alpha(self) -> bool:
+        return True
+    
+    @property
+    def supports_quality_setting(self) -> bool:
+        return False
+    
+    @property
+    def supports_multiple_export(self) -> bool:
+        return True
+    
+    @property
+    def supports_include_original(self) -> bool:
+        return False
+    
+    @property
+    def is_sequence(self) -> bool:
+        return False
+    
+    def get_available_output_types(self) -> List[str]:
+        return [
+            'Segmentation-Matte', 'Segmentation-Alpha', 'Segmentation-BGcolor',
+            'Matting-Matte', 'Matting-Alpha', 'Matting-BGcolor', 'ObjectRemoval'
+        ]
+    
+    def get_codec_name(self) -> str:
+        return "ffv1"
+    
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        return 'bgra' if has_alpha else 'bgr0'
+    
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        return {'level': '3'}
+
+
+class H264Format(ExportFormat):
+    @property
+    def format_id(self) -> str:
+        return "x264"
+    
+    @property
+    def display_name(self) -> str:
+        return "H.264 Video"
+    
+    @property
+    def file_extension(self) -> str:
+        return ".mp4"
+    
+    @property
+    def supports_alpha(self) -> bool:
+        return False
+    
+    @property
+    def supports_quality_setting(self) -> bool:
+        return True
+    
+    @property
+    def supports_multiple_export(self) -> bool:
+        return True
+    
+    @property
+    def supports_include_original(self) -> bool:
+        return False
+    
+    @property
+    def is_sequence(self) -> bool:
+        return False
+    
+    def get_available_output_types(self) -> List[str]:
+        return [
+            'Segmentation-Matte', 'Segmentation-BGcolor',
+            'Matting-Matte', 'Matting-BGcolor', 'ObjectRemoval'
+        ]
+    
+    def get_codec_name(self) -> str:
+        return "libx264"
+    
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        return 'yuv420p'
+    
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        return {'crf': str(quality), 'preset': 'medium'}
+
+
+class H265Format(ExportFormat):
+    @property
+    def format_id(self) -> str:
+        return "x265"
+    
+    @property
+    def display_name(self) -> str:
+        return "H.265 Video"
+    
+    @property
+    def file_extension(self) -> str:
+        return ".mp4"
+    
+    @property
+    def supports_alpha(self) -> bool:
+        return False
+    
+    @property
+    def supports_quality_setting(self) -> bool:
+        return True
+    
+    @property
+    def supports_multiple_export(self) -> bool:
+        return True
+    
+    @property
+    def supports_include_original(self) -> bool:
+        return False
+    
+    @property
+    def is_sequence(self) -> bool:
+        return False
+    
+    def get_available_output_types(self) -> List[str]:
+        return [
+            'Segmentation-Matte', 'Segmentation-BGcolor',
+            'Matting-Matte', 'Matting-BGcolor', 'ObjectRemoval'
+        ]
+    
+    def get_codec_name(self) -> str:
+        return "libx265"
+    
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        return 'yuv420p'
+    
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        return {'crf': str(quality), 'preset': 'medium'}
+
+
+class VP9Format(ExportFormat):
+    @property
+    def format_id(self) -> str:
+        return "vp9"
+    
+    @property
+    def display_name(self) -> str:
+        return "VP9 Video"
+    
+    @property
+    def file_extension(self) -> str:
+        return ".webm"
+    
+    @property
+    def supports_alpha(self) -> bool:
+        return True
+    
+    @property
+    def supports_quality_setting(self) -> bool:
+        return True
+    
+    @property
+    def supports_multiple_export(self) -> bool:
+        return True
+    
+    @property
+    def supports_include_original(self) -> bool:
+        return False
+    
+    @property
+    def is_sequence(self) -> bool:
+        return False
+    
+    def get_available_output_types(self) -> List[str]:
+        return [
+            'Segmentation-Matte', 'Segmentation-Alpha', 'Segmentation-BGcolor',
+            'Matting-Matte', 'Matting-Alpha', 'Matting-BGcolor', 'ObjectRemoval'
+        ]
+    
+    def get_codec_name(self) -> str:
+        return "libvpx-vp9"
+    
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        return 'yuva420p' if has_alpha else 'yuv420p'
+    
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        return {
+            'crf': str(quality),
+            'b': '0',
+            'row-mt': '1'
+        }
+    
+    def get_quality_label(self) -> str:
+        return "Quality (CQ):"
+    
+    def get_quality_range(self) -> tuple:
+        return (0, 63)
+
+
+# === Sequence Formats ===
+
+class EXRSequenceFormat(ExportFormat):
+    @property
+    def format_id(self) -> str:
+        return "exr"
+    
+    @property
+    def display_name(self) -> str:
+        return "EXR Sequence"
+    
+    @property
+    def file_extension(self) -> str:
+        return ".####.exr"
+    
+    @property
+    def supports_alpha(self) -> bool:
+        return False  # EXR uses separate layers instead
+    
+    @property
+    def supports_quality_setting(self) -> bool:
+        return False
+    
+    @property
+    def supports_multiple_export(self) -> bool:
+        return False  # EXR exports all objects as layers
+    
+    @property
+    def supports_include_original(self) -> bool:
+        return True
+    
+    @property
+    def is_sequence(self) -> bool:
+        return True
+    
+    def get_available_output_types(self) -> List[str]:
+        return ['Segmentation-Matte', 'Matting-Matte']
+    
+    def get_codec_name(self) -> Optional[str]:
+        return None
+    
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        return ''  # Not used for EXR
+    
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        return {}
+
+
+class PNGSequenceFormat(ExportFormat):
+    @property
+    def format_id(self) -> str:
+        return "png"
+    
+    @property
+    def display_name(self) -> str:
+        return "PNG Sequence"
+    
+    @property
+    def file_extension(self) -> str:
+        return ".####.png"
+    
+    @property
+    def supports_alpha(self) -> bool:
+        return True
+    
+    @property
+    def supports_quality_setting(self) -> bool:
+        return False
+    
+    @property
+    def supports_multiple_export(self) -> bool:
+        return False
+    
+    @property
+    def supports_include_original(self) -> bool:
+        return False
+    
+    @property
+    def is_sequence(self) -> bool:
+        return True
+    
+    def get_available_output_types(self) -> List[str]:
+        return [
+            'Segmentation-Matte', 'Segmentation-Alpha', 'Segmentation-BGcolor',
+            'Matting-Matte', 'Matting-Alpha', 'Matting-BGcolor', 'ObjectRemoval'
+        ]
+    
+    def get_codec_name(self) -> Optional[str]:
+        return None
+    
+    def get_pixel_format(self, has_alpha: bool) -> str:
+        return ''  # Not used for PNG
+    
+    def get_codec_options(self, quality: int) -> Dict[str, str]:
+        return {}
+
+
+# === Format Registry ===
+
+class FormatRegistry:
+    """Central registry for all export formats"""
+    
+    _formats = {
+        'prores': ProResFormat(),
+        'ffv1': FFV1Format(),
+        'x264': H264Format(),
+        'x265': H265Format(),
+        'vp9': VP9Format(),
+        'exr': EXRSequenceFormat(),
+        'png': PNGSequenceFormat(),
+    }
+    
+    @classmethod
+    def get_format(cls, format_id: str) -> ExportFormat:
+        """Get format by ID"""
+        return cls._formats.get(format_id)
+    
+    @classmethod
+    def get_all_formats(cls) -> List[ExportFormat]:
+        """Get all available formats in display order"""
+        return [
+            cls._formats['prores'],
+            cls._formats['ffv1'],
+            cls._formats['x264'],
+            cls._formats['x265'],
+            cls._formats['vp9'],
+            cls._formats['exr'],
+            cls._formats['png'],
+        ]
+    
+    @classmethod
+    def get_format_ids(cls) -> List[str]:
+        """Get all format IDs"""
+        return list(cls._formats.keys())

--- a/sammie/export_workers.py
+++ b/sammie/export_workers.py
@@ -1,0 +1,461 @@
+# sammie/export_workers.py
+"""
+Export worker threads for different export modes.
+"""
+import os
+import av
+import numpy as np
+import OpenEXR
+import Imath
+from fractions import Fraction
+from PIL import Image
+from PySide6.QtCore import QThread, Signal
+from sammie import sammie
+from .export_formats import ExportSettings, FormatRegistry
+import re
+
+
+class BaseExportWorker(QThread):
+    """Base worker thread for exports"""
+    
+    progress_updated = Signal(int)
+    status_updated = Signal(str)
+    finished = Signal(bool, str)
+    
+    def __init__(self, settings: ExportSettings, points, total_frames, parent_window=None):
+        super().__init__()
+        self.settings = settings
+        self.points = points
+        self.total_frames = total_frames
+        self.should_cancel = False
+        self.parent_window = parent_window
+        
+        # Calculate frame range
+        if settings.use_inout and settings.in_point is not None and settings.out_point is not None:
+            self.start_frame = max(0, settings.in_point)
+            self.end_frame = min(total_frames - 1, settings.out_point)
+        else:
+            self.start_frame = 0
+            self.end_frame = total_frames - 1
+        
+        self.export_frame_count = self.end_frame - self.start_frame + 1
+    
+    def cancel(self):
+        self.should_cancel = True
+    
+    def _get_view_options(self, output_type: str, antialias: bool) -> dict:
+        """Get view options for rendering"""
+        settings_mgr = self.parent_window.settings_mgr if self.parent_window else None
+        bgcolor = (0, 255, 0)
+        if settings_mgr:
+            bgcolor = settings_mgr.get_session_setting("bgcolor", (0, 255, 0))
+        
+        view_options = {'view_mode': output_type}
+        
+        if output_type.startswith('Segmentation-'):
+            view_options['antialias'] = antialias
+            if output_type == 'Segmentation-BGcolor':
+                view_options['bgcolor'] = bgcolor
+        elif output_type.startswith('Matting-'):
+            if output_type == 'Matting-BGcolor':
+                view_options['bgcolor'] = bgcolor
+        elif output_type == 'ObjectRemoval':
+            view_options['show_removal_mask'] = False
+        
+        return view_options
+    
+    @staticmethod
+    def _sanitize_name(name: str) -> str:
+        """Sanitize name for use in filenames or layer names"""
+        if not name:
+            return "unnamed"
+        sanitized = re.sub(r'[^\w]', '_', name)
+        sanitized = re.sub(r'_+', '_', sanitized)
+        sanitized = sanitized.strip('_')
+        return sanitized[:20] if len(sanitized) > 20 else sanitized or "unnamed"
+
+
+class VideoExportWorker(BaseExportWorker):
+    """Worker for video export (single or multiple files)"""
+    
+    def __init__(self, settings: ExportSettings, points, total_frames, 
+                 output_paths: list, object_ids: list = None, parent_window=None):
+        super().__init__(settings, points, total_frames, parent_window)
+        self.output_paths = output_paths  # List of output paths
+        self.object_ids = object_ids or [settings.object_id]
+        self.format = FormatRegistry.get_format(settings.format_id)
+    
+    def run(self):
+        try:
+            if len(self.output_paths) > 1:
+                self._export_multiple()
+            else:
+                self._export_single(self.output_paths[0], self.object_ids[0])
+                if not self.should_cancel:
+                    frame_range_msg = f" (frames {self.start_frame}-{self.end_frame})" if self.settings.use_inout else ""
+                    self.finished.emit(True, f"Video exported successfully{frame_range_msg} to {self.output_paths[0]}")
+        except InterruptedError as e:
+            # User cancelled - emit with cancel message
+            self.finished.emit(False, str(e))
+        except Exception as e:
+            import traceback
+            tb = traceback.format_exc()
+            self.finished.emit(False, f"Export failed: {e}\n\n{tb}")
+    
+    def _export_multiple(self):
+        """Export multiple videos for different objects"""
+        total_progress_steps = len(self.output_paths) * self.export_frame_count
+        current_step = 0
+        exported_files = []
+        
+        for i, (output_path, object_id) in enumerate(zip(self.output_paths, self.object_ids)):
+            if self.should_cancel:
+                self._cleanup_files(exported_files)
+                raise InterruptedError("Export was cancelled by user")
+            
+            self.status_updated.emit(f"Exporting object {object_id} ({i+1}/{len(self.output_paths)})...")
+            
+            try:
+                self._export_single(output_path, object_id, current_step, total_progress_steps)
+                exported_files.append(output_path)
+                current_step += self.export_frame_count
+            except InterruptedError:
+                # Re-raise cancel exception after cleanup
+                self._cleanup_files(exported_files)
+                raise
+            except Exception as e:
+                self._cleanup_files(exported_files)
+                raise e
+        
+        if not self.should_cancel:
+            self.status_updated.emit("All exports completed successfully")
+            files_text = "\n".join([os.path.basename(f) for f in exported_files])
+            frame_range_msg = f" (frames {self.start_frame}-{self.end_frame})" if self.settings.use_inout else ""
+            self.finished.emit(True, f"Successfully exported {len(exported_files)} videos{frame_range_msg}:\n{files_text}")
+    
+    def _export_single(self, output_path: str, object_id: int, 
+                      progress_offset: int = 0, total_progress_steps: int = None):
+        """Export a single video file"""
+        if total_progress_steps is None:
+            total_progress_steps = self.export_frame_count
+        
+        object_id_filter = None if object_id == -1 else object_id
+        has_alpha = 'Alpha' in self.settings.output_type
+        
+        # Create output container
+        container = av.open(output_path, mode='w')
+        
+        # Get frame rate
+        fps = sammie.VideoInfo.fps
+        fps_rational = self._convert_fps_to_fraction(fps)
+        
+        # Create video stream
+        stream = container.add_stream(self.format.get_codec_name(), rate=fps_rational)
+        stream.width = sammie.VideoInfo.width
+        stream.height = sammie.VideoInfo.height
+        stream.pix_fmt = self.format.get_pixel_format(has_alpha)
+        
+        # Set codec options
+        codec_options = self.format.get_codec_options(self.settings.quality)
+        if has_alpha and self.format.supports_alpha:
+            if self.format.format_id == 'prores':
+                codec_options['profile'] = '4'
+        
+        for key, value in codec_options.items():
+            stream.options[key] = value
+        
+        try:
+            pts_counter = 0
+            for i, frame_num in enumerate(range(self.start_frame, self.end_frame + 1)):
+                if self.should_cancel:
+                    container.close()
+                    if os.path.exists(output_path):
+                        os.remove(output_path)
+                    raise InterruptedError("Export was cancelled by user")
+                
+                # Get frame data
+                view_options = self._get_view_options(self.settings.output_type, self.settings.antialias)
+                frame_array = sammie.update_image(
+                    frame_num, view_options, self.points, 
+                    return_numpy=True, object_id_filter=object_id_filter
+                )
+                
+                if frame_array is None:
+                    continue
+                
+                # Handle alpha channel
+                if has_alpha and frame_array.shape[2] != 4:
+                    alpha_channel = np.full((frame_array.shape[0], frame_array.shape[1], 1), 255, dtype=np.uint8)
+                    frame_array = np.concatenate([frame_array, alpha_channel], axis=2)
+                elif not has_alpha and frame_array.shape[2] == 4:
+                    frame_array = frame_array[:, :, :3]
+                
+                # Create AV frame
+                av_format = 'rgba' if has_alpha else 'rgb24'
+                av_frame = av.VideoFrame.from_ndarray(frame_array, format=av_format)
+                av_frame.pts = pts_counter
+                pts_counter += 1
+                
+                # Encode and write
+                for packet in stream.encode(av_frame):
+                    container.mux(packet)
+                
+                # Update progress
+                current_progress_step = progress_offset + i + 1
+                progress = int(current_progress_step / total_progress_steps * 100)
+                self.progress_updated.emit(progress)
+            
+            # Flush remaining frames
+            for packet in stream.encode():
+                container.mux(packet)
+        finally:
+            container.close()
+    
+    @staticmethod
+    def _convert_fps_to_fraction(fps: float) -> Fraction:
+        """Convert float FPS to fraction for exact representation"""
+        if abs(fps - 29.97) < 0.01:
+            return Fraction(30000, 1001)
+        elif abs(fps - 23.976) < 0.01:
+            return Fraction(24000, 1001)
+        elif abs(fps - 59.94) < 0.01:
+            return Fraction(60000, 1001)
+        else:
+            return Fraction(fps).limit_denominator()
+    
+    @staticmethod
+    def _cleanup_files(file_paths: list):
+        """Clean up partially exported files"""
+        for path in file_paths:
+            if os.path.exists(path):
+                try:
+                    os.remove(path)
+                except:
+                    pass
+
+
+class SequenceExportWorker(BaseExportWorker):
+    """Worker for frame sequence export (EXR, PNG)"""
+    
+    def __init__(self, settings: ExportSettings, points, total_frames, 
+                 base_filename: str, parent_window=None):
+        super().__init__(settings, points, total_frames, parent_window)
+        self.base_filename = base_filename
+        self.format = FormatRegistry.get_format(settings.format_id)
+    
+    def run(self):
+        try:
+            if self.format.format_id == 'exr':
+                self._export_exr_sequence()
+            elif self.format.format_id == 'png':
+                self._export_png_sequence()
+            else:
+                raise ValueError(f"Unsupported sequence format: {self.format.format_id}")
+        except InterruptedError as e:
+            # User cancelled - emit with cancel message
+            self.finished.emit(False, str(e))
+        except Exception as e:
+            import traceback
+            tb = traceback.format_exc()
+            self.finished.emit(False, f"Export failed: {e}\n\n{tb}")
+    
+    def _export_exr_sequence(self):
+        """Export EXR frame sequence with multiple object layers"""
+        output_dir = self.settings.output_dir
+        
+        # Get all unique object IDs
+        all_object_ids = sorted(set(point['object_id'] for point in self.points))
+        if not all_object_ids:
+            self.finished.emit(False, "No objects found to export")
+            return
+        
+        # Get object names
+        object_names = {}
+        if self.parent_window and hasattr(self.parent_window, 'settings_mgr'):
+            object_names = self.parent_window.settings_mgr.get_session_setting("object_names", {})
+        
+        exported_files = []
+        
+        for i, frame_num in enumerate(range(self.start_frame, self.end_frame + 1)):
+            if self.should_cancel:
+                self._cleanup_files(exported_files)
+                raise InterruptedError("Export was cancelled by user")
+            
+            self.status_updated.emit(f"Exporting frame {frame_num + 1}/{self.end_frame + 1}...")
+            
+            frame_filename = f"{self.base_filename}.{frame_num:04d}.exr"
+            frame_path = os.path.join(output_dir, frame_filename)
+            
+            try:
+                exr_data = {}
+                view_options = self._get_view_options(self.settings.output_type, self.settings.antialias)
+                
+                # Export each object as a layer
+                for obj_id in all_object_ids:
+                    mask_array = sammie.update_image(
+                        frame_num, view_options, self.points,
+                        return_numpy=True, object_id_filter=obj_id
+                    )
+                    
+                    if mask_array is not None:
+                        # Convert to grayscale if needed
+                        if len(mask_array.shape) == 3 and mask_array.shape[2] > 1:
+                            mask_array = mask_array[:, :, 0]
+                        
+                        # Normalize to 0-1 range
+                        if mask_array.dtype == np.uint8:
+                            mask_array = mask_array.astype(np.float32) / 255.0
+                        elif mask_array.dtype != np.float32:
+                            mask_array = mask_array.astype(np.float32)
+                        
+                        # Generate layer name
+                        object_name = object_names.get(str(obj_id), "")
+                        if object_name:
+                            sanitized_name = self._sanitize_name(object_name)
+                            layer_name = f'{obj_id}_{sanitized_name}'
+                        else:
+                            layer_name = f'{obj_id}'
+                        
+                        exr_data[layer_name] = mask_array
+                
+                # Include original frame if requested
+                if self.settings.include_original:
+                    original_view_options = {'view_mode': 'None'}
+                    original_array = sammie.update_image(
+                        frame_num, original_view_options, self.points,
+                        return_numpy=True, object_id_filter=None
+                    )
+                    
+                    if original_array is not None:
+                        if original_array.dtype == np.uint8:
+                            original_array = original_array.astype(np.float32) / 255.0
+                        elif original_array.dtype != np.float32:
+                            original_array = original_array.astype(np.float32)
+                        
+                        # Split RGB channels
+                        if len(original_array.shape) == 3 and original_array.shape[2] >= 3:
+                            exr_data['original.R'] = original_array[:, :, 0]
+                            exr_data['original.G'] = original_array[:, :, 1]
+                            exr_data['original.B'] = original_array[:, :, 2]
+                        else:
+                            exr_data['original'] = original_array
+                
+                # Write EXR file
+                if exr_data:
+                    self._write_exr_file(frame_path, exr_data)
+                    exported_files.append(frame_path)
+                
+                progress = int((i + 1) / self.export_frame_count * 100)
+                self.progress_updated.emit(progress)
+                
+            except InterruptedError:
+                # Re-raise cancel exception
+                raise
+            except Exception as e:
+                print(f"Error exporting frame {frame_num + 1}: {e}")
+                self._cleanup_files(exported_files)
+                raise e
+        
+        if not self.should_cancel:
+            self.status_updated.emit("EXR sequence export completed")
+            frame_range_msg = f" (frames {self.start_frame}-{self.end_frame})" if self.settings.use_inout else ""
+            self.finished.emit(True, f"Successfully exported {len(exported_files)} EXR frames{frame_range_msg} to {output_dir}")
+    
+    def _export_png_sequence(self):
+        """Export PNG frame sequence"""
+        output_dir = self.settings.output_dir
+        object_id_filter = None if self.settings.object_id == -1 else self.settings.object_id
+        has_alpha = 'Alpha' in self.settings.output_type
+        
+        exported_files = []
+        
+        for i, frame_num in enumerate(range(self.start_frame, self.end_frame + 1)):
+            if self.should_cancel:
+                self._cleanup_files(exported_files)
+                raise InterruptedError("Export was cancelled by user")
+            
+            self.status_updated.emit(f"Exporting frame {frame_num + 1}/{self.end_frame + 1}...")
+            
+            frame_filename = f"{self.base_filename}.{frame_num:04d}.png"
+            frame_path = os.path.join(output_dir, frame_filename)
+            
+            try:
+                # Get frame data
+                view_options = self._get_view_options(self.settings.output_type, self.settings.antialias)
+                frame_array = sammie.update_image(
+                    frame_num, view_options, self.points,
+                    return_numpy=True, object_id_filter=object_id_filter
+                )
+                
+                if frame_array is not None:
+                    # Handle alpha channel
+                    if has_alpha and frame_array.shape[2] != 4:
+                        alpha_channel = np.full((frame_array.shape[0], frame_array.shape[1], 1), 255, dtype=np.uint8)
+                        frame_array = np.concatenate([frame_array, alpha_channel], axis=2)
+                    elif not has_alpha and frame_array.shape[2] == 4:
+                        frame_array = frame_array[:, :, :3]
+                    
+                    # Save as PNG using PIL
+                    mode = 'RGBA' if has_alpha else 'RGB'
+                    img = Image.fromarray(frame_array, mode=mode)
+                    img.save(frame_path, 'PNG')
+                    exported_files.append(frame_path)
+                
+                progress = int((i + 1) / self.export_frame_count * 100)
+                self.progress_updated.emit(progress)
+                
+            except InterruptedError:
+                # Re-raise cancel exception
+                raise
+            except Exception as e:
+                print(f"Error exporting frame {frame_num + 1}: {e}")
+                self._cleanup_files(exported_files)
+                raise e
+        
+        if not self.should_cancel:
+            self.status_updated.emit("PNG sequence export completed")
+            frame_range_msg = f" (frames {self.start_frame}-{self.end_frame})" if self.settings.use_inout else ""
+            self.finished.emit(True, f"Successfully exported {len(exported_files)} PNG frames{frame_range_msg} to {output_dir}")
+    
+    @staticmethod
+    def _write_exr_file(filepath: str, data_dict: dict):
+        """Write EXR file with multiple layers"""
+        try:
+            first_layer = next(iter(data_dict.values()))
+            height, width = first_layer.shape
+            
+            header = OpenEXR.Header(width, height)
+            FLOAT = Imath.PixelType(Imath.PixelType.FLOAT)
+            
+            # Declare channels
+            for name in data_dict.keys():
+                header['channels'][name] = Imath.Channel(FLOAT)
+            
+            # Enable PIZ compression
+            header['compression'] = Imath.Compression(Imath.Compression.PIZ_COMPRESSION)
+            
+            out = OpenEXR.OutputFile(filepath, header)
+            
+            # Prepare channel data
+            channels = {}
+            for name, arr in data_dict.items():
+                if arr.dtype != np.float32:
+                    arr = arr.astype(np.float32)
+                arr = np.ascontiguousarray(arr)
+                channels[name] = arr.tobytes()
+            
+            out.writePixels(channels)
+            out.close()
+            
+        except Exception as e:
+            raise RuntimeError(f"Failed to write EXR file: {e}")
+    
+    @staticmethod
+    def _cleanup_files(file_paths: list):
+        """Clean up partially exported files"""
+        for path in file_paths:
+            if os.path.exists(path):
+                try:
+                    os.remove(path)
+                except:
+                    pass

--- a/sammie/settings_manager.py
+++ b/sammie/settings_manager.py
@@ -69,6 +69,7 @@ class ApplicationSettings:
     export_use_input_folder: bool = True
     export_filename_template: str = "{input_name}-{output_type}"
     export_antialias: bool = False
+    export_use_inout: bool = True
     export_quantizer: int = 14
     export_include_original: bool = False
     export_multiple: bool = False


### PR DESCRIPTION
The export dialog was a mess and had lots of duplicated code.

This refactor splits the export dialog into 3 files:
1) export_dialog.py - Handles the actual gui dialog
2) export_workers.py - Handles the processing for generating the frames and writing them to file
3) export_formats.py - A registry of the various export formats and their capabilities.

This greatly simplifies the export dialog and should make it easier to make changes to it in the future.

The option to export a PNG sequence has also been added.